### PR TITLE
Bumped stunnel version number

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/stunnel.yml
+++ b/playbooks/roles/streisand-mirror/vars/stunnel.yml
@@ -7,7 +7,7 @@ stunnel_mirror_href_base: "/mirror/stunnel"
 stunnel_michal_trojnara_key_id: "0xFCD53E9D74C732D1"
 stunnel_michal_trojnara_expected_fingerprint: "Key fingerprint = F6B1 BFC5 5F32 243F B2C8  919A FCD5 3E9D 74C7 32D1"
 
-stunnel_version: "5.08"
+stunnel_version: "5.09"
 stunnel_base_download_url: "http://www.stunnel.org/downloads"
 
 stunnel_installer_filename: "stunnel-{{ stunnel_version }}-installer.exe"


### PR DESCRIPTION
Current stunnel verison is no longer hosted at the given url. Causes the installer to fail. I've tested and verified that bumping the version number lets it succeed.