### PR TITLE
Update stunnel version to 5.14

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/stunnel.yml
+++ b/playbooks/roles/streisand-mirror/vars/stunnel.yml
@@ -7,7 +7,7 @@ stunnel_mirror_href_base: "/mirror/stunnel"
 stunnel_michal_trojnara_key_id: "0xB1048932DD3AAAA3"
 stunnel_michal_trojnara_expected_fingerprint: "Key fingerprint = AC91 5EA3 0645 D9D3 D4DA  E4FE B104 8932 DD3A AAA3"
 
-stunnel_version: "5.13"
+stunnel_version: "5.14"
 stunnel_base_download_url: "http://www.stunnel.org/downloads"
 
 stunnel_installer_filename: "stunnel-{{ stunnel_version }}-installer.exe"


### PR DESCRIPTION
Installation failed for me today with the following:

```
failed: [45.55.175.9] => (item=http://www.stunnel.org/downloads/stunnel-5.13-installer.exe) => {"dest": "/var/www/streisand/mirror/stunnel", "failed": true, "gid": 33, "group": "www-data", "item": "http://www.stunnel.org/downloads/stunnel-5.13-installer.exe", "mode": "0755", "owner": "www-data", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 33, "url": "http://www.stunnel.org/downloads/stunnel-5.13-installer.exe"}
msg: Request failed
failed: [45.55.175.9] => (item=http://www.stunnel.org/downloads/stunnel-5.13-installer.exe.asc) => {"dest": "/var/www/streisand/mirror/stunnel", "failed": true, "gid": 33, "group": "www-data", "item": "http://www.stunnel.org/downloads/stunnel-5.13-installer.exe.asc", "mode": "0755", "owner": "www-data", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 33, "url": "http://www.stunnel.org/downloads/stunnel-5.13-installer.exe.asc"}
msg: Request failed
failed: [45.55.175.9] => (item=http://www.stunnel.org/downloads/stunnel-5.13.tar.gz) => {"dest": "/var/www/streisand/mirror/stunnel", "failed": true, "gid": 33, "group": "www-data", "item": "http://www.stunnel.org/downloads/stunnel-5.13.tar.gz", "mode": "0755", "owner": "www-data", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 33, "url": "http://www.stunnel.org/downloads/stunnel-5.13.tar.gz"}
msg: Request failed
failed: [45.55.175.9] => (item=http://www.stunnel.org/downloads/stunnel-5.13.tar.gz.asc) => {"dest": "/var/www/streisand/mirror/stunnel", "failed": true, "gid": 33, "group": "www-data", "item": "http://www.stunnel.org/downloads/stunnel-5.13.tar.gz.asc", "mode": "0755", "owner": "www-data", "response": "HTTP Error 404: Not Found", "size": 4096, "state": "directory", "status_code": 404, "uid": 33, "url": "http://www.stunnel.org/downloads/stunnel-5.13.tar.gz.asc"}
msg: Request failed
```

Looks like stunnel.org no longer hosts the download for v5.13, updated the version in the playbook to v5.14.