### PR TITLE
Fixed logic in Debian 7 warning

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Warn users if the server's Linux distribution is not Debian 7
   pause: prompt="Debian 7 is the only fully tested distribution; the setup will probably fail. Press Enter if you still want to continue."
-  when: ansible_distribution != "Debian" and ansible_distribution_major_version != "7"
+  when: ansible_distribution != "Debian" or ansible_distribution_major_version != "7"
 
 # Set default variables
 - include: set-default-variables.yml


### PR DESCRIPTION
Show show the warning when the OS is not Debian based OR not version 7.