### PR TITLE
Don't hardcode eth0 in dante configuration

### DIFF
--- a/playbooks/roles/dante/tasks/main.yml
+++ b/playbooks/roles/dante/tasks/main.yml
@@ -3,9 +3,9 @@
   apt: name=dante-server
 
 - name: Copy Dante configuration file
-  copy: src=danted.conf
-        dest=/etc/danted.conf
-        owner=root
-        group=root
-        mode=644
+  template: src=danted.conf.j2
+            dest=/etc/danted.conf
+            owner=root
+            group=root
+            mode=644
   notify: Restart Dante

--- a/playbooks/roles/dante/templates/danted.conf.j2
+++ b/playbooks/roles/dante/templates/danted.conf.j2
@@ -1,7 +1,7 @@
 logoutput: syslog
 
 internal: 10.8.0.1 port = 1080
-external: eth0
+external: {{ ansible_default_ipv4.interface }}
 
 user.privileged: proxy
 user.notprivileged: nobody


### PR DESCRIPTION
Ansible provides `ansible_default_ipv4.interface`, which may or may not
be eth0. For example, on OpenVZ hosts, this is usually venet0.