### PR TITLE
Make openvpn crypto parameters easier to modify

### DIFF
--- a/playbooks/roles/openvpn/defaults/main.yml
+++ b/playbooks/roles/openvpn/defaults/main.yml
@@ -13,3 +13,6 @@ openvpn_clients:
 
 openvpn_port: "636"
 openvpn_protocol: "tcp"
+openvpn_key_size: "2048"
+openvpn_cipher: "AES-256-CBC"
+openvpn_auth_digest: "SHA256"

--- a/playbooks/roles/openvpn/vars/main.yml
+++ b/playbooks/roles/openvpn/vars/main.yml
@@ -1,9 +1,6 @@
 ---
 openvpn_days_valid: "1825"
 openvpn_request_subject: "/C={{ openvpn_key_country }}/ST={{ openvpn_key_province }}/L={{ openvpn_key_city }}/O={{ openvpn_key_org }}/OU={{ openvpn_key_ou }}"
-openvpn_key_size: "2048"
-openvpn_cipher: "AES-256-CBC"
-openvpn_auth_digest: "SHA256"
 openvpn_path: "/etc/openvpn"
 openvpn_ca: "{{ openvpn_path }}/ca"
 openvpn_dhparam: "{{ openvpn_path }}/dh{{ openvpn_key_size }}.pem"


### PR DESCRIPTION
Because of ansible's [variable precedence][], non-default variables can't be easily modified via config files. Because the OpenVPN crypto parameters might be something someone wants to modify, they should instead be set as default values.

[variable precedence]: http://docs.ansible.com/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable