### PR TITLE
add Linode Singapore DC, replace Tokyo as default

### DIFF
--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -13,6 +13,7 @@
       "4": 7
       "5": 6
       "6": 8
+      "7": 9
 
   vars_prompt:
     - name: "linode_datacenter"
@@ -24,8 +25,9 @@
           4. London
           5. Newark
           6. Tokyo
-        Please choose the number of your region. Press enter for default (#6) region.
-      default: "6"
+          7. Singapore
+        Please choose the number of your region. Press enter for default (#7) region.
+      default: "7"
       private: no
 
     - name: "linode_server_name"


### PR DESCRIPTION
Tokyo availability is limited, Singapore was recently added and does not have these limitations