### PR TITLE
Use new stunnel download locations for simplified version updates.

### DIFF
--- a/playbooks/roles/streisand-mirror/tasks/stunnel.yml
+++ b/playbooks/roles/streisand-mirror/tasks/stunnel.yml
@@ -16,3 +16,11 @@
            project_expected_fingerprint="{{ stunnel_michal_trojnara_expected_fingerprint }}"
            project_mirror_location="{{ stunnel_mirror_location }}"
            project_download_urls="{{ stunnel_download_urls }}"
+
+- name: Get the current stunnel version from the downloaded source file
+  shell: ls *.tar.gz | tail -n 1 | sed -e 's/stunnel-\(.*\)\.tar\.gz/\1/'
+         chdir={{ stunnel_mirror_location }}
+  register: stunnel_latest_check
+
+- name: Set the target stunnel version
+  set_fact: stunnel_version="{{ stunnel_latest_check.stdout }}"

--- a/playbooks/roles/streisand-mirror/vars/stunnel.yml
+++ b/playbooks/roles/streisand-mirror/vars/stunnel.yml
@@ -7,22 +7,21 @@ stunnel_mirror_href_base: "/mirror/stunnel"
 stunnel_michal_trojnara_key_id: "0xB1048932DD3AAAA3"
 stunnel_michal_trojnara_expected_fingerprint: "Key fingerprint = AC91 5EA3 0645 D9D3 D4DA  E4FE B104 8932 DD3A AAA3"
 
-stunnel_version: "5.19"
-stunnel_base_download_url: "http://www.stunnel.org/downloads"
+stunnel_base_download_url: "https://www.stunnel.org/"
 
 stunnel_installer_filename: "stunnel-{{ stunnel_version }}-installer.exe"
 stunnel_installer_sig_filename: "{{ stunnel_installer_filename }}.asc"
 stunnel_installer_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_installer_filename }}"
 stunnel_installer_sig_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_installer_sig_filename }}"
-stunnel_installer_url: "{{ stunnel_base_download_url }}/{{ stunnel_installer_filename }}"
-stunnel_installer_sig_url: "{{ stunnel_base_download_url }}/{{ stunnel_installer_sig_filename }}"
+stunnel_installer_url: "{{ stunnel_base_download_url }}/stunnel-latest-installer.exe"
+stunnel_installer_sig_url: "{{ stunnel_base_download_url }}/stunnel-latest-installer.exe.asc"
 
 stunnel_source_filename: "stunnel-{{ stunnel_version }}.tar.gz"
 stunnel_source_sig_filename: "{{ stunnel_source_filename }}.asc"
 stunnel_source_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_source_filename }}"
 stunnel_source_sig_href: "{{ stunnel_mirror_href_base }}/{{ stunnel_source_sig_filename }}"
-stunnel_source_url: "{{ stunnel_base_download_url }}/{{ stunnel_source_filename }}"
-stunnel_source_sig_url: "{{ stunnel_base_download_url }}/{{ stunnel_source_sig_filename }}"
+stunnel_source_url: "{{ stunnel_base_download_url }}/stunnel-latest.tar.gz"
+stunnel_source_sig_url: "{{ stunnel_base_download_url }}/stunnel-latest.tar.gz.asc"
 
 stunnel_download_urls:
   - "{{ stunnel_installer_url }}"


### PR DESCRIPTION
Michal Trojnara (the maintainer of stunnel) has graciously set up stable download locations that will always redirect to the latest installer and source code files. This will prevent things from breaking when new versions are released and will also obviate the need for manual updates to the `stunnel_version` variable in the `playbooks/roles/streisand-mirror/vars/stunnel.yml` file.