### PR TITLE
Adding in Ping Keepalives to Servers Internal IP

### DIFF
--- a/playbooks/roles/openvpn/templates/client-common.j2
+++ b/playbooks/roles/openvpn/templates/client-common.j2
@@ -11,6 +11,8 @@ comp-lzo
 key-direction 1
 verb 3
 route {{ streisand_ipv4_address }} 255.255.255.255 net_gateway
+ping 10.8.0.1
+ping-restart 30
 
 <ca>
 {{ openvpn_ca_contents.stdout }}


### PR DESCRIPTION
Adds in ping keepalives into OpenVPN Client common configuration, this causes keep alives to be sent, resolves #180 :)