### PR TITLE
Updated deprecated usage of hostfile config value

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,5 +1,5 @@
 [defaults]
-hostfile = inventory
+inventory = inventory
 
 # This is a convenient setting for a brand new Streisand server that
 # you are connecting to for the first time. However, this line should be


### PR DESCRIPTION
As of version 1.9, the usage of hostfile is deprecated. The new usage is inventory. For more information, please see Ansible config documentation:

http://docs.ansible.com/ansible/intro_configuration.html#hostfile

This is a relatively minor fix that should be easily mergeable without further changes. 