### PR TITLE
made some tasks asynchronous to speed up deployment

### DIFF
--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -25,6 +25,9 @@
 - name: Compile and install Libreswan (this will take a while)
   shell: make programs && make install
          chdir={{ libreswan_compilation_directory }}
+  async: 300
+  poll: 0
+  register: compile_libreswan
 
 - name: Generate IPsec configuration file
   template: src=ipsec.conf.j2

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -14,6 +14,13 @@
     - ca
     - server
 
+- name: Generate Diffie-Hellman parameters asynchronously
+  command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }}
+           creates={{ openvpn_dhparam }}
+  async: 300
+  poll: 0
+  register: dhparams_creation
+
 - name: Create directories for clients
   file: path={{ openvpn_path}}/{{ item }}
         state=directory
@@ -127,10 +134,6 @@
     - openvpn_client_certificates.results
     - openvpn_client_keys.results
 
-- name: Generate Diffie-Hellman parameters (this will take a while)
-  command: openssl dhparam -out {{ openvpn_dhparam }} {{ openvpn_key_size }}
-           creates={{ openvpn_dhparam }}
-
 - name: Enable IPv4 traffic forwarding
   sysctl: name=net.ipv4.ip_forward
           value=1
@@ -142,6 +145,12 @@
 - name: Copy OpenVPN configuration file into place
   template: src=etc_openvpn_server.conf.j2
             dest=/etc/openvpn/server.conf
+
+- name: Verify Diffie-Hellman parameters have been created
+  async_status: jid={{ dhparams_creation.ansible_job_id }}
+  register: async_task_result
+  until: async_task_result.finished
+  retries: 100
 
 - name: Restart OpenVPN so the 10.8.0.0 interface is available to dnsmasq
   service: name=openvpn

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -128,6 +128,12 @@
         state=directory
         recurse=yes
 
+- name: Verify libreswan compilation has completed
+  async_status: jid={{ compile_libreswan.ansible_job_id }}
+  register: async_task_result
+  until: async_task_result.finished
+  retries: 100
+
 - meta: flush_handlers
 
 - name: Success!


### PR DESCRIPTION
Noticed two tasks that take a long time to complete and hold up the rest of the playbook. Made these two tasks run asynchronously, so they can run in the background while the rest of the playbook continues. 
- The DH parameters generation for OpenVPN needed to be complete before the service starts, so I placed a task to verify that it completed before the openvpn restart task. 
- As for compiling Libreswan, I placed the verify task at the end of the play right before the handlers run. 