### PR TITLE
Add new Seoul region for AWS playbook

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -8,14 +8,15 @@
   vars:
     regions:
       "1": "ap-northeast-1"
-      "2": "ap-southeast-1"
-      "3": "ap-southeast-2"
-      "4": "eu-west-1"
-      "5": "eu-central-1"
-      "6": "sa-east-1"
-      "7": "us-east-1"
-      "8": "us-west-1"
-      "9": "us-west-2"
+      "2": "ap-northeast-2"
+      "3": "ap-southeast-1"
+      "4": "ap-southeast-2"
+      "5": "eu-west-1"
+      "6": "eu-central-1"
+      "7": "sa-east-1"
+      "8": "us-east-1"
+      "9": "us-west-1"
+      "10": "us-west-2"
 
   # This variable file is included so the ec2-security-group role knows
   # which port to open for SSH
@@ -27,16 +28,17 @@
       prompt: >
         What region should the server be located in?
           1. Asia Pacific     (Tokyo)
-          2. Asia Pacific     (Singapore)
-          3. Asia Pacific     (Sydney)
-          4. EU               (Ireland)
-          5. EU               (Germany)
-          6. South America    (Sao Paulo)
-          7. US East          (Northern Virginia)
-          8. US West          (Northern California)
-          9. US West          (Oregon)
-        Please choose the number of your region. Press enter for default (#2) region.
-      default: "2"
+          2. Asia Pacific     (Seoul)
+          3. Asia Pacific     (Singapore)
+          4. Asia Pacific     (Sydney)
+          5. EU               (Ireland)
+          6. EU               (Germany)
+          7. South America    (Sao Paulo)
+          8. US East          (Northern Virginia)
+          9. US West          (Northern California)
+          10. US West         (Oregon)
+        Please choose the number of your region. Press enter for default (#3) region.
+      default: "3"
       private: no
 
     - name: "aws_instance_name_var"


### PR DESCRIPTION
AWS just add a new region `ap-northeast-2 (Seoul)`. Add it to the regions list and keep the default region
to Singapore. 