### PR TITLE
Fix Shadowsocks OS X instructions to use correct UI terminology

### DIFF
--- a/playbooks/roles/shadowsocks/templates/instructions.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions.md.j2
@@ -30,7 +30,7 @@ Shadowsocks
 1. Download [ShadowsocksX](/mirror/#shadowsocks).
 1. Double-click the DMG, and drag the icon into your Applications folder.
 1. Launch ShadowsocksX. You will be prompted to enter your password so that your system proxy settings can be modified.
-1. Look for the Shadowsocks paper plane icon in your taskbar and click on it.
+1. Look for the Shadowsocks paper plane icon in your menu bar and click on it.
 1. Make sure the QR code below is centered and completely visible, and choose *Scan QR Code from Screen...*
 
    ![Shadowsocks QR code](/shadowsocks/shadowsocks-qr-code.png)
@@ -39,7 +39,7 @@ Shadowsocks
    1. Make sure `{{ shadowsocks_encryption_method }}` is selected for the *Encryption* value.
    1. Enter `{{ shadowsocks_password.stdout }}` as the *Password*.
    1. Click *OK*.
-1. Click on the Shadowsocks icon in the taskbar again, and choose *Global Mode*.
+1. Click on the Shadowsocks icon in the menu bar again, and choose *Global Mode*.
 1. You can use the Shadowsocks icon to enable/disable the VPN. The color of the icon will change based on whether or not it is active.
 1. That's it! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 


### PR DESCRIPTION
In the OS X portion of the Shadowsocks instructions, two references to 'taskbar’ are made, however, 'menu bar' is the correct usage. Both instances of the former term were replaced with the latter in order to reduce any ambiguity.