### PR TITLE
Add task to install dictionary packages

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -1,5 +1,8 @@
 ---
 streisand_common_packages:
+  # Required for generating passwords (not pre-installed on Ubuntu minimal)
+  - dictionaries-common
+  - wamerican-huge
   # Used to compile Libreswan and OpenConnect Server (ocserv)
   - build-essential
   # Used to perform API requests, including the version check for


### PR DESCRIPTION
These aren't installed by default on ubuntu-minimal and as such cause problems when setting up streisand

This is semi-related to #262. There just needs to be a way now to check if Python is installed and if not install it.