### PR TITLE
Prevent hanging on re-run

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -3,6 +3,9 @@
   apt: name={{ item }}
        state=absent
   with_items: "{{ apache_packages_to_remove }}"
+  
+- name: Stop nginx for configuration
+  service: name=nginx state=stopped
 
 - name: Make sure that nothing is listening on port 80 on the public interface
   wait_for: host={{ streisand_ipv4_address }}


### PR DESCRIPTION
Running this script on certain servers fails a lot of times and requires 4-5 re-executions of ansible-playbook. I'm not trying to fix that.

After one of the re-runs Nginx was already running but client-side docs weren't generated yet, and Ansible hanged on "Make sure that nothing is listening on port 80". Stopping nginx manually allowed Ansible to proceed, so my commit is making this automated.