### PR TITLE
Amend instructions for the Shadowsocks client on Android

### DIFF
--- a/playbooks/roles/shadowsocks/templates/instructions.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions.md.j2
@@ -76,14 +76,13 @@ Once you have Shadowsocks running locally, you'll need to forward your browser t
 ### Android ###
 1. Download Shadowsocks for Android from [Google Play](https://play.google.com/store/apps/details?id=com.github.shadowsocks). If Google Play is blocked in your country, you can [download a mirrored copy](/mirror/#shadowsocks) from this server!
 1. Launch the application.
-1. Tap the menu icon in the top-left of the screen.
-1. Tap *Add Profile*.
+1. Tap the Shadowsocks icon in the top-left of the screen.
+1. Tap the *+* icon in the bottom-right.
 1. Select *Scan QR code*.
 1. Use your phone to scan this image, or if you are using your phone _right now_ you can choose the *Manual Settings* option and copy and paste the information from the Linux section above:
   
    ![Shadowsocks QR code](/shadowsocks/shadowsocks-qr-code.png)
-1. Uncheck the *CHN Route* option unless you live in China and want to bypass Shadowsocks when visiting Chinese websites.
-1. Slide the switch to *On*.
+1. Tap the plane icon on the top.
 1. Accept the Android VPN connection warning.
 1. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 


### PR DESCRIPTION
Recent versions of the client has adopted Material Design, and this commit
updates the instructions to reflect the changes.

I've removed the part about the CHN routes, as it's no longer on by default.

Here is a screenshot of the new version:
![Screenshot](https://cloud.githubusercontent.com/assets/2189609/15799055/9fa20916-2a82-11e6-8ff6-aac92da006d2.png)

