### PR TITLE
Update genesis-amazon to use Elastic IP

### DIFF
--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -64,3 +64,4 @@
 
 - name: New EC2 servers are occasionally slow to process incoming SSH connections even after the OpenSSH daemon has started up. Pause for 90 seconds.
   pause: seconds=90
+  

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -43,12 +43,21 @@
             search_regex=OpenSSH
             timeout=600
 
+- name: Allocate and associate Elastic IP
+  local_action:
+    module: ec2_eip
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    region: "{{ aws_region }}"
+    device_id: "{{ streisand_server.instances[0].id }}"
+  register: instance_eip
+
 - name: Create the in-memory inventory group
-  add_host: name={{ streisand_server.instances[0].public_ip }}
+  add_host: name={{ instance_eip.public_ip }}
             groups=streisand-host
 
 - name: Set the streisand_ipv4_address variable
-  set_fact: streisand_ipv4_address="{{ streisand_server.instances[0].public_ip }}"
+  set_fact: streisand_ipv4_address="{{ instance_eip.public_ip }}"
 
 - name: Set the streisand_server_name variable
   set_fact: streisand_server_name="{{ aws_instance_name }}"


### PR DESCRIPTION
For EC2 instances with public IP addresses, it’s usually desirable to assign an Elastic IP to the instance to ensure that the public IP does not change.

Without an Elastic IP, the public IP address will change any time the instance is stopped or restarted. If the public IP of the instance changes, it will break all sorts of things.

This update will associate an Elastic IP address to the EC2 instance immediately after instance creation, and assigns the Elastic IP to the streisand_ipv4_address variable for use in the rest of the playbook.