### PR TITLE
Unattended upgrades

### DIFF
--- a/playbooks/roles/common/files/50unattended-upgrades
+++ b/playbooks/roles/common/files/50unattended-upgrades
@@ -3,6 +3,19 @@ Unattended-Upgrade::Allowed-Origins {
     // ${distro_id} and ${distro_codename} will be automatically expanded
     "${distro_id} stable";
     "${distro_id} ${distro_codename}-security";
+
+    //Autoupdate OpenVPN
+    "Freight:${distro_codename}";
+
+    //Autoupdate Tor
+    "TorProject:${distro_codename}";
+
+    //Autoupdate nginx
+    "nginx:${distro_codename}";
+
+    //Autoupdate shadowsocks-libev
+    "shadowsocks-libev:${distro_codename}";
+
 //  "${distro_id} ${distro_codename}-updates";
 //  "${distro_id} ${distro_codename}-proposed-updates";
 };
@@ -23,8 +36,13 @@ Unattended-Upgrade::Package-Blacklist {
 
 // Do automatic removal of new unused dependencies after the upgrade
 // (equivalent to apt-get autoremove)
-//Unattended-Upgrade::Remove-Unused-Dependencies "false";
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
 
 // Automatically reboot *WITHOUT CONFIRMATION* if a
 // the file /var/run/reboot-required is found after the upgrade
-//Unattended-Upgrade::Automatic-Reboot "false";
+Unattended-Upgrade::Automatic-Reboot "true";
+
+// If automatic reboot is enabled and needed, reboot at the specific
+// time instead of immediately
+//  Default: "now"
+Unattended-Upgrade::Automatic-Reboot-Time "00:00";

--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: Add the official Nginx repository
   apt_repository:
-    repo: "deb http://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_lsb.codename }} nginx"
+    repo: "deb https://nginx.org/packages/{{ ansible_distribution|lower }}/ {{ ansible_lsb.codename }} nginx"
 
 - name: Install Nginx
   apt:

--- a/playbooks/roles/rc-local/tasks/main.yml
+++ b/playbooks/roles/rc-local/tasks/main.yml
@@ -4,4 +4,4 @@
             dest=/etc/rc.local
             owner=root
             group=root
-            mode=755
+            mode=0755

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -5,7 +5,7 @@
   with_file: tor-signing.key
 
 - name: Add the Tor repository
-  apt_repository: repo="deb http://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main"
+  apt_repository: repo="deb https://deb.torproject.org/torproject.org {{ ansible_lsb.codename }} main"
 
 - name: Install the package to keep the Tor signing key current
   apt: name=deb.torproject.org-keyring


### PR DESCRIPTION
Unattended upgrades will auto-update: Tor, OpenVPN, shadowsocks-libev and nginx
unattended upgrades will explicitly auto-remove unused dependencies
Unattended upgrades will reboot the server at midnight (depending on where the server location timezone is)
Tor and Nginx deb repos re-configured to use https instead of http

rc.local mode using octet notation (0755 instead of 755)

unattended upgrades can be tested by executing the following command: unattended-upgrade --debug --dry-run

note: tried switching shadowsocks deb repo to https but got errors :(

Edit: OpenVPN repo also uses https, but was configured to do so in another PR I have made: PR  #322).
shadowsocks-libev using https in the deb repo resulted in the following error:

`
W: Failed to fetch https://shadowsocks.org/ubuntu/dists/trusty/main/binary-amd64/Packages  gnutls_handshake() failed: Handshake failed

W: Failed to fetch https://shadowsocks.org/ubuntu/dists/trusty/main/binary-i386/Packages  gnutls_handshake() failed: Handshake failed

`

Invoking the same URL with curl works fine, which leads me to believe that the gnutls library has some sort of bug.
