### PR TITLE
Create option to use FQDN for streisand server certificates

### DIFF
--- a/playbooks/roles/common/tasks/set-default-variables.yml
+++ b/playbooks/roles/common/tasks/set-default-variables.yml
@@ -36,3 +36,18 @@
   set_fact:
     streisand_server_name: "{{ ansible_hostname }}"
   when: streisand_server_name is not defined
+
+- name: Set the streisand_cn_name variable to streisand_ipv4_address if it is not defined or empty
+  set_fact:
+    streisand_cn_name: "{{ streisand_ipv4_address }}"
+  when: (streisand_cn_name is undefined) or (streisand_cn_name == "")
+
+- name: Set ocserv_is_dyndns to true 
+  set_fact:
+    ocserv_is_dyndns: true
+  when: streisand_cn_name != streisand_ipv4_address
+  
+- name: Set ocserv_is_dyndns to true 
+  set_fact:
+    ocserv_is_dyndns: false
+  when: streisand_cn_name == streisand_ipv4_address

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -30,3 +30,9 @@ streisand_local_directory: "generated-docs"
 
 streisand_header_template: "/tmp/header.html"
 streisand_footer_template: "/tmp/footer.html"
+
+## Uncomment to set streisand_cn_name to the domain name of your server (eg, vpn.example.com),
+## if you don't want to use the IP address. This can be useful for servers that change their IP,
+## because you don't have to distribute new certificates. You will need to set a DNS entry to your
+## Streisand server before accessing it.
+# streisand_cn_name: "vpn.example.com"

--- a/playbooks/roles/openconnect/templates/client.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/client.tmpl.j2
@@ -1,4 +1,4 @@
-cn = {{ streisand_ipv4_address }}
+cn = {{ streisand_cn_name }}
 unit = "users"
 expiration_days = {{ ocserv_days_valid }}
 signing_key

--- a/playbooks/roles/openconnect/templates/config.j2
+++ b/playbooks/roles/openconnect/templates/config.j2
@@ -9,6 +9,7 @@ server-cert = {{ ocserv_server_certificate_file }}
 server-key = {{ ocserv_server_key_file }}
 ca-cert = {{ ocserv_ca_certificate_file }}
 isolate-workers = true
+listen-host-is-dyndns = {{ ocserv_is_dyndns }}
 keepalive = 32400
 dpd = 240
 mobile-dpd = 1800

--- a/playbooks/roles/openconnect/templates/server.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/server.tmpl.j2
@@ -1,4 +1,4 @@
-cn = {{ streisand_ipv4_address }}
+cn = {{ streisand_cn_name }}
 organization = "{{ ocserv_server_organization }}"
 expiration_days = {{ ocserv_days_valid }}
 signing_key

--- a/playbooks/roles/openconnect/vars/main.yml
+++ b/playbooks/roles/openconnect/vars/main.yml
@@ -32,7 +32,7 @@ ocserv_server_certificate_file: "{{ ocserv_path }}/server-cert.pem"
 ocserv_server_key_file: "{{ ocserv_path }}/server-key.pem"
 ocserv_server_template_file: "{{ ocserv_path }}/server.tmpl"
 
-ocserv_client_name: "streisand-openconnect-{{ streisand_ipv4_address }}"
+ocserv_client_name: "streisand-openconnect-{{ streisand_cn_name }}"
 ocserv_client_certificate_file: "{{ ocserv_path }}/client-cert.pem"
 ocserv_client_key_file: "{{ ocserv_path }}/client-key.pem"
 ocserv_client_template_file: "{{ ocserv_path }}/client.tmpl"

--- a/playbooks/roles/openvpn/templates/client-common.j2
+++ b/playbooks/roles/openvpn/templates/client-common.j2
@@ -10,7 +10,7 @@ tls-version-min 1.2
 comp-lzo
 key-direction 1
 verb 3
-route {{ streisand_ipv4_address }} 255.255.255.255 net_gateway
+route {{ streisand_cn_name }} 255.255.255.255 net_gateway
 
 <ca>
 {{ openvpn_ca_contents.stdout }}

--- a/playbooks/roles/openvpn/templates/openssl-server-certificate.cnf.j2
+++ b/playbooks/roles/openvpn/templates/openssl-server-certificate.cnf.j2
@@ -54,7 +54,7 @@ organizationalUnitName = Organizational Unit Name (eg, section)
 organizationalUnitName_default = {{ openvpn_key_ou }}
 
 commonName = Common Name (eg, your name or your server\'s hostname)
-commonName_default = server
+commonName_default = {{ streisand_cn_name }}
 
 [ server ]
 basicConstraints=CA:FALSE

--- a/playbooks/roles/openvpn/vars/main.yml
+++ b/playbooks/roles/openvpn/vars/main.yml
@@ -4,7 +4,7 @@ openvpn_request_subject: "/C={{ openvpn_key_country }}/ST={{ openvpn_key_provinc
 openvpn_path: "/etc/openvpn"
 openvpn_ca: "{{ openvpn_path }}/ca"
 openvpn_hmac_firewall: "{{ openvpn_path }}/ta.key"
-openvpn_server: "{{ streisand_ipv4_address }}"
+openvpn_server: "{{ streisand_cn_name }}"
 
 openvpn_direct_profile_filename: "{{ openvpn_server }}-direct.ovpn"
 openvpn_direct_udp_profile_filename: "{{ openvpn_server }}-direct-udp.ovpn"

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -15,7 +15,7 @@
            creates={{ openssl_ca_certificate }}
 
 - name: Create the certificate request
-  command: openssl req -new -nodes -days {{ nginx_days_valid }} -newkey rsa:{{ streisand_gateway_rsa_key_size }} -keyout {{ nginx_private_key }} -out {{ nginx_self_signed_certificate_request }} -subj "/C={{ nginx_key_country }}/ST={{ nginx_key_province }}/L={{ nginx_key_city }}/O={{ nginx_key_org }}/OU={{ nginx_key_ou }}/CN={{ streisand_ipv4_address }}"
+  command: openssl req -new -nodes -days {{ nginx_days_valid }} -newkey rsa:{{ streisand_gateway_rsa_key_size }} -keyout {{ nginx_private_key }} -out {{ nginx_self_signed_certificate_request }} -subj "/C={{ nginx_key_country }}/ST={{ nginx_key_province }}/L={{ nginx_key_city }}/O={{ nginx_key_org }}/OU={{ nginx_key_ou }}/CN={{ streisand_cn_name }}"
            creates={{ nginx_self_signed_certificate_request }}
 
 - name: Seed a blank database file that will be used when generating the self-signed certificate

--- a/playbooks/roles/streisand-gateway/vars/main.yml
+++ b/playbooks/roles/streisand-gateway/vars/main.yml
@@ -1,5 +1,5 @@
 ---
-streisand_gateway_url: "https://{{ streisand_ipv4_address }}"
+streisand_gateway_url: "https://{{ streisand_cn_name }}"
 
 streisand_gateway_htpasswd_file: "/etc/nginx/htpasswd"
 streisand_gateway_password_file: "/etc/nginx/gateway-password.txt"

--- a/playbooks/roles/stunnel/templates/stunnel-local.conf.j2
+++ b/playbooks/roles/stunnel/templates/stunnel-local.conf.j2
@@ -2,4 +2,4 @@ client = yes
 
 [stunnel]
 accept = 127.0.0.1:{{ stunnel_local_port }}
-connect = {{ streisand_ipv4_address }}:{{ stunnel_remote_port }}
+connect = {{ streisand_cn_name }}:{{ stunnel_remote_port }}


### PR DESCRIPTION
Hi @jlund ,

I created an option to use the domain name as CN in the certificates (see also #320 for discussion).

**Problem:** 
The default setting in Streisand is to create server certficates
based on the IP address. This creates error messages when the IP
changes.

The IP might change for example on an AWS EC2 instance
that is stopped and restarted later, or moved to another region.
To avoid the hassle of re-creating and distributing certificates,
a server should be able to have a DNS entry (ie, vpn.example.com).

**Proposed solution:** 
This edit creates this option. A new variable
   `streisand_cn_name`
can be defined in
   `playbooks/roles/common/vars/main.yml`

If it is defined, the CN name of the certificates will change to
whatever domain name streisand_cn_name is set to.

If it is not defined, there is no change in behaviour.

**CAUTION:**
- Only tested on openconnect and AWS.
- The documentation might also need adaptation (currently a mix of IP and hostname.
- Did not touch TOR.
