### PR TITLE
Update Android and Windows Shadowsocks mirrors

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/shadowsocks.yml
+++ b/playbooks/roles/streisand-mirror/vars/shadowsocks.yml
@@ -5,18 +5,18 @@ shadowsocks_mirror_location: "{{ streisand_mirror_location }}/shadowsocks"
 shadowsocks_mirror_href_base: "/mirror/shadowsocks"
 
 # Android
-shadowsocks_android_version: "2.9.5"
+shadowsocks_android_version: "2.10.5"
 shadowsocks_android_filename: "shadowsocks-nightly-{{ shadowsocks_android_version }}.apk"
 shadowsocks_android_href: "{{ shadowsocks_mirror_href_base }}/{{ shadowsocks_android_filename }}"
 shadowsocks_android_url: "https://github.com/shadowsocks/shadowsocks-android/releases/download/v{{ shadowsocks_android_version }}/shadowsocks-nightly-{{ shadowsocks_android_version }}.apk"
-shadowsocks_android_checksum: "sha256:6b6d0f3703f88cc0fd4e8e04d38f4da385725e40803ed121b26e4c576dcded1e"
+shadowsocks_android_checksum: "sha256:b3a7dd8349940d5a87a74d4e3ef23e7ae3d3a037930b298c88e1a566858284e3"
 
 # Windows
-shadowsocks_gui_version: "2.5.6"
-shadowsocks_gui_filename: "Shadowsocks-win-{{ shadowsocks_gui_version }}.zip"
+shadowsocks_gui_version: "3.0"
+shadowsocks_gui_filename: "Shadowsocks-{{ shadowsocks_gui_version }}.zip"
 shadowsocks_gui_href: "{{ shadowsocks_mirror_href_base }}/{{ shadowsocks_gui_filename }}"
-shadowsocks_gui_url: "https://github.com/shadowsocks/shadowsocks-csharp/releases/download/{{ shadowsocks_gui_version }}/{{ shadowsocks_gui_filename }}"
-shadowsocks_gui_checksum: "sha256:f061a3885630696637496bcd9e40cacf13ac7b27fb630d16e91aef0ae4011c62"
+shadowsocks_gui_url: "https://github.com/shadowsocks/shadowsocks-windows/releases/download/{{ shadowsocks_gui_version }}/{{ shadowsocks_gui_filename }}"
+shadowsocks_gui_checksum: "sha256:aa1689d0e4fe83becafdaae7862fa3bd0335229f80cf55d00d4c12bcb1d65fe8"
 
 # OS X
 shadowsocks_x_version: "2.6.3"


### PR DESCRIPTION
Latest versions as obtained from GitHub

Fixes #349  because it turns out v2.10.5 of the Android app has an integrated barcode scanner