### PR TITLE
Use environment variable as default for DO token

### DIFF
--- a/playbooks/digitalocean.yml
+++ b/playbooks/digitalocean.yml
@@ -44,7 +44,8 @@
       private: no
 
     - name: "do_access_token"
-      prompt: "\n\nNew API access tokens can be generated in the DigitalOcean control panel.\nhttps://cloud.digitalocean.com/settings/applications\n  * When generating a new token, please note that the Write Scope is necessary\n    in order to create Droplets.\n\nWhat is your DigitalOcean Access Token?\n"
+      prompt: "\n\nNew API access tokens can be generated in the DigitalOcean control panel.\nhttps://cloud.digitalocean.com/settings/applications\n  * When generating a new token, please note that the Write Scope is necessary\n    in order to create Droplets.\n\nIf you enter nothing here, the environment variable DIGITALOCEAN_API_KEY will be used.\n\nWhat is your DigitalOcean Access Token?\n"
+      default: "{{ lookup('env', 'DIGITALOCEAN_API_KEY') }}"
       private: no
 
     - name: "do_ssh_name"


### PR DESCRIPTION
Default the `do_access_token` to the environment variable
`DIGITALOCEAN_API_KEY`. This variable is used by doctl and other
tools and is often exported in the environment of a user which
leverages these tools.

The result is a little bit ugly in the prompt format, but it does
make provisioning easier from a user perspective:

```
If you enter nothing here, the environment variable DIGITALOCEAN_API_KEY will be used.

What is your DigitalOcean Access Token?
[{{ lookup('env', 'DIGITALOCEAN_API_KEY') }}]:
```