### PR TITLE
Use wait_for instead of pause when building DO

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 generated-docs
+*.retry

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -52,6 +52,10 @@
   set_fact:
     streisand_server_name: "{{ do_server_name }}"
 
-- name: New DigitalOcean servers are occasionally slow to process incoming SSH connections even after the OpenSSH daemon has started up. Pause for 90 seconds.
-  pause:
-    seconds: 90
+- name: Wait for SSH to be ready for connections (up to five minutes)
+  wait_for:
+    host: "{{ streisand_ipv4_address }}"
+    port: 22
+    delay: 10
+    timeout: 300
+    search_regex: "OpenSSH"


### PR DESCRIPTION
Rather than twiddling our thumbs for 90 seconds, the `wait_for`
module will poll port 22 until it is ready for connections. This
is faster and more resilient than using the `pause` module here.

Also add *.retry files to the .gitignore