### PR TITLE
Add l2tp/ipsec to AWS builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Services Provided
 * L2TP/IPsec using [Libreswan](https://libreswan.org/) and [xl2tpd](https://www.xelerance.com/software/xl2tpd/)
   * A randomly chosen pre-shared key and password are generated.
   * Windows, OS X, Android, and iOS users can all connect using the native VPN support that is built into each operating system without installing any additional software.
-  * *Streisand does not install L2TP/IPsec on Amazon EC2 or Google GCE servers by default because the instances cannot bind directly to their public IP addresses which makes IPsec routing nearly impossible.*
+  * *Streisand does not install L2TP/IPsec on Google GCE servers by default because the instances cannot bind directly to their public IP addresses which makes IPsec routing nearly impossible.*
 * [Monit](https://mmonit.com/monit/)
   * Monitors process health and automatically restarts services in the unlikely event that they crash or become unresponsive.
 * [OpenSSH](http://www.openssh.com/)

--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -90,22 +90,11 @@
   remote_user: ubuntu
   become: yes
 
-  vars:
-    # The rc-local role normally expects to configure firewall rules for
-    # L2TP/IPsec. Streisand does not install L2TP/IPsec on EC2 servers
-    # by default because the instances cannot bind directly to their
-    # public IP addresses which makes IPsec routing nearly impossible.
-    #
-    # This variable is therefore set to an empty value.
-    l2tp_ipsec_firewall_rules: ""
-
-    # Similarly, we don't want to display a link to nonexistent
-    # L2TP/IPsec information on the Gateway index page
-    l2tp_ipsec_gateway_location: ""
-
   roles:
     - common
+    # openconnect must be run before the l2tp-ipsec role otherwise there are compilation issues
     - openconnect
+    - l2tp-ipsec
     - openvpn
     - stunnel
     - shadowsocks
@@ -128,6 +117,7 @@
   # These variable files are included so the ec2-security-group role
   # knows which ports to open
   vars_files:
+    - roles/l2tp-ipsec/defaults/main.yml
     - roles/openconnect/defaults/main.yml
     - roles/openvpn/defaults/main.yml
     - roles/shadowsocks/defaults/main.yml

--- a/playbooks/roles/ec2-security-group/tasks/main.yml
+++ b/playbooks/roles/ec2-security-group/tasks/main.yml
@@ -49,6 +49,20 @@
         from_port: "{{ nginx_port }}"
         to_port: "{{ nginx_port }}"
         cidr_ip: 0.0.0.0/0
+      # L2TP/IPSec
+      # ---
+      - proto: udp
+        from_port: "{{ ike_port }}"
+        to_port: "{{ ike_port }}"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        from_port: "{{ ipsec_port }}"
+        to_port: "{{ ipsec_port }}"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        from_port: "{{ l2tp_port }}"
+        to_port: "{{ l2tp_port }}"
+        cidr_ip: 0.0.0.0/0
       # OpenConnect (ocserv)
       # ---
       - proto: tcp


### PR DESCRIPTION
As mentioned in #311, L2TP/IPSec works without issue on AWS. This commit adds the `l2tp-ipsec` (and the associated security group roles) back into the Amazon playbook.

Edit: I'd imagine this can also be applied to GCE, I just haven't got around to it.