### PR TITLE
[AWS] Add VPC support

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -39,6 +39,20 @@
       default: "2"
       private: no
 
+    - name: "aws_vpc_id_var"
+      prompt: |
+
+        Which VPC would you like to create the server and security group rules in? (ex. vpc-89d740ee)
+        Press enter to use the default VPC.
+      private: no
+
+    - name: "aws_vpc_subnet_id_var"
+      prompt: |
+
+        Which subnet should the server receive an address from? (ex. subnet-78d9a232)
+        Press enter to use the default subnet.
+      private: no
+
     - name: "aws_instance_name_var"
       prompt: "\nWhat should the server be named? Press enter for default (streisand).\n"
       default: "streisand"
@@ -64,6 +78,16 @@
     - name: Set the AWS Region fact
       set_fact:
         aws_region: "{{ regions[aws_region_var] }}"
+
+    - name: Set the AWS VPC ID fact
+      set_fact:
+        aws_vpc_id: "{{ aws_vpc_id_var }}"
+      when: aws_vpc_id_var != ""
+
+    - name: Set the AWS VPC Subnet ID fact
+      set_fact:
+        aws_vpc_subnet_id: "{{ aws_vpc_subnet_id_var }}"
+      when: aws_vpc_subnet_id_var != ""
 
     - name: Set the AWS Instance Name fact
       set_fact:

--- a/playbooks/roles/ec2-security-group/tasks/main.yml
+++ b/playbooks/roles/ec2-security-group/tasks/main.yml
@@ -5,6 +5,7 @@
     name: "{{ aws_security_group }}"
     description: Security group for Streisand
     region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id|default(omit) }}"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
 
@@ -18,6 +19,7 @@
     name: "{{ aws_security_group }}"
     description: Security group for Streisand
     region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id|default(omit) }}"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     rules:
@@ -40,6 +42,7 @@
     name: "{{ aws_security_group }}"
     description: Security group for Streisand
     region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id|default(omit) }}"
     aws_access_key: "{{ aws_access_key }}"
     aws_secret_key: "{{ aws_secret_key }}"
     rules:

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -32,6 +32,8 @@
     instance_type: "{{ aws_instance_type }}"
     image: "{{ aws_ami_id }}"
     region: "{{ aws_region }}"
+    vpc_subnet_id: "{{ aws_vpc_subnet_id|default(omit) }}"
+    assign_public_ip: "{{ aws_vpc_subnet_id is defined and aws_vpc_subnet_id != '' }}"
     key_name: streisand-ssh
     group: "{{ aws_security_group }}"
     instance_tags:
@@ -53,6 +55,7 @@
     aws_secret_key: "{{ aws_secret_key }}"
     region: "{{ aws_region }}"
     device_id: "{{ streisand_server.instances[0].id }}"
+    in_vpc: "{{ aws_vpc_id is defined and aws_vpc_id != '' }}"
   register: instance_eip
 
 - name: Create the in-memory inventory group


### PR DESCRIPTION
Allows the user to optionally provide VPC and Subnet IDs when creating
a Streisand server. These values are then passed when creating security
group rules and the EC2 instances later on in the build process.