### PR TITLE
[AWS] Add autorecover alarm

### DIFF
--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -39,6 +39,28 @@
     wait: yes
   register: streisand_server
 
+# The auto-recover action is currently only available in us-east-1
+- name: Create CloudWatch alarm to auto-recover instance (us-east-1 only)
+  ec2_metric_alarm:
+    name: "autorecover-{{ aws_instance_name }}"
+    description: "This alarm will auto-recover the EC2 instance on host failure"
+    state: present
+    region: "{{ aws_region }}"
+    namespace: "AWS/EC2"
+    metric: StatusCheckFailed_System
+    statistic: Minimum
+    comparison: ">"
+    threshold: 0.0
+    period: 60
+    evaluation_periods: 2
+    dimensions:
+      InstanceId: "{{ streisand_server.instances[0].id }}"
+    alarm_actions:
+      - "arn:aws:automate:{{ aws_region }}:ec2:recover"
+  when:
+    - aws_region == "us-east-1"
+    - aws_instance_type.startswith(("t2", "c3", "c4", "m3", "r3"))
+
 - name: Wait until the server has finished booting and OpenSSH is accepting connections
   wait_for:
     host: "{{ streisand_server.instances[0].public_ip }}"

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -45,6 +45,8 @@
     name: "autorecover-{{ aws_instance_name }}"
     description: "This alarm will auto-recover the EC2 instance on host failure"
     state: present
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
     region: "{{ aws_region }}"
     namespace: "AWS/EC2"
     metric: StatusCheckFailed_System


### PR DESCRIPTION
This task configures a CloudWatch metric alarm to trigger auto-recovery
if the host system is down for 2 minutes.

AWS (via CloudWatch) supports a feature known as auto-recovery, which
will respawn an instance on host system failure. The recovered instance
is identical to the original instance, including instance ID,
private/elastic IP addresses, and metadata.

Currently this feature is only available in the `us-east-1` region for
the C3, C4, M3, R3, and T2 instance types.

@jlund Sorry for all the PRs. I know it's a lot of work maintaining these things... I'd be happy to help in any way that I can.