### PR TITLE
Include streisand.yml in amazon.yml

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -108,33 +108,7 @@
     - genesis-amazon
 
 
-- name: Configure the Server and install required software
-# ========================================================
-  hosts: streisand-host
-
-  # The standard streisand.yml is not included because the Ubuntu AMI
-  # uses 'ubuntu' instead of 'root'
-  remote_user: ubuntu
-  become: yes
-
-  roles:
-    - common
-    # OpenConnect must be set up before L2TP/IPsec in order to avoid
-    # compilation issues.
-    - openconnect
-    - l2tp-ipsec
-    - openvpn
-    - stunnel
-    - shadowsocks
-    - ssh
-    - tinyproxy
-    - tor-bridge
-    - sslh
-    - monit
-    - ufw
-    - streisand-mirror
-    - streisand-gateway
-
+- include: streisand.yml
 
 - name: Open all service ports
 # ============================

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -71,6 +71,8 @@
   add_host:
     name: "{{ instance_eip.public_ip }}"
     groups: streisand-host
+    ansible_user: ubuntu
+    ansible_become: yes
 
 - name: Set the streisand_ipv4_address variable
   set_fact:


### PR DESCRIPTION
Adding `ansible_user` and `ansible_become` as host variables with the
`add_host` module satisfy the login requirements which are needed for
connecting to EC2 instances, and allows us to include the main play
from streisand.yml.