### PR TITLE
Add l2tp/ipsec support to GCE builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ Services Provided
 * L2TP/IPsec using [Libreswan](https://libreswan.org/) and [xl2tpd](https://www.xelerance.com/software/xl2tpd/)
   * A randomly chosen pre-shared key and password are generated.
   * Windows, OS X, Android, and iOS users can all connect using the native VPN support that is built into each operating system without installing any additional software.
-  * *Streisand does not install L2TP/IPsec on Google GCE servers by default because the instances cannot bind directly to their public IP addresses which makes IPsec routing nearly impossible.*
 * [Monit](https://mmonit.com/monit/)
   * Monitors process health and automatically restarts services in the unlikely event that they crash or become unresponsive.
 * [OpenSSH](http://www.openssh.com/)

--- a/playbooks/google.yml
+++ b/playbooks/google.yml
@@ -99,41 +99,7 @@
     - genesis-google
 
 
-- name: Configure the Server and install required software
-# ========================================================
-  hosts: streisand-host
-
-  remote_user: root
-
-  # The standard streisand.yml is not included in order to skip L2TP/Ipsec
-
-  vars:
-    # The rc-local role normally expects to configure firewall rules for
-    # L2TP/IPsec. Streisand does not install L2TP/IPsec on EC2 servers
-    # by default because the instances cannot bind directly to their
-    # public IP addresses which makes IPsec routing nearly impossible.
-    #
-    # This variable is therefore set to an empty value.
-    l2tp_ipsec_firewall_rules: ""
-
-    # Similarly, we don't want to display a link to nonexistent
-    # L2TP/IPsec information on the Gateway index page
-    l2tp_ipsec_gateway_location: ""
-
-  roles:
-    - common
-    - openconnect
-    - openvpn
-    - stunnel
-    - shadowsocks
-    - ssh
-    - tinyproxy
-    - tor-bridge
-    - sslh
-    - monit
-    - ufw
-    - streisand-mirror
-    - streisand-gateway
+- include: streisand.yml
 
 
 - name: Open all service ports
@@ -146,6 +112,7 @@
   # knows which ports to open
   vars_files:
     - roles/openconnect/defaults/main.yml
+    - roles/l2tp-ipsec/defaults/main.yml
     - roles/openvpn/defaults/main.yml
     - roles/shadowsocks/defaults/main.yml
     - roles/ssh/defaults/main.yml

--- a/playbooks/roles/gce-network/tasks/main.yml
+++ b/playbooks/roles/gce-network/tasks/main.yml
@@ -60,3 +60,16 @@
     credentials_file: "{{ gce_json_file_location }}"
     project_id: "{{ gce_project_id }}"
   when: open_all_service_ports
+
+- name: Open L2TP/IPsec ports in the GCE firewall
+  local_action:
+    module: gce_net
+    name: "{{ gce_network }}"
+    fwname: "streisand-l2tp-ipsec"
+    allowed: "udp:{{ ike_port }},{{ ipsec_port }},{{ l2tp_port }}"
+    state: "present"
+    src_range: 0.0.0.0/0
+    service_account_email: "{{ gce_service_account_email }}"
+    credentials_file: "{{ gce_json_file_location }}"
+    project_id: "{{ gce_project_id }}"
+  when: open_all_service_ports


### PR DESCRIPTION
Just as in #370, adding support for L2TP/IPsec, but for Google Compute Engine this time around.

Closes #311