### PR TITLE
Update OpenVPN streisand-mirror

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/openvpn.yml
+++ b/playbooks/roles/streisand-mirror/vars/openvpn.yml
@@ -7,7 +7,7 @@ openvpn_mirror_href_base: "/mirror/openvpn"
 openvpn_samuli_seppanen_key_id: "0xC29D97ED198D22A3"
 openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = 0330 0E11 FED1 6F59 715F  9996 C29D 97ED 198D 22A3"
 
-openvpn_version: "2.3.11"
+openvpn_version: "2.3.12"
 openvpn_base_download_url: "http://swupdate.openvpn.org/community/releases"
 
 openvpn_source_filename: "openvpn-{{ openvpn_version }}.tar.gz"


### PR DESCRIPTION
updates OpenVPN to the latest 2.3.12 release for the local streisand-mirror