### PR TITLE
Add ShadowsocksX-NG to streisand-mirror

### DIFF
--- a/playbooks/roles/shadowsocks/templates/instructions.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions.md.j2
@@ -27,9 +27,9 @@ Shadowsocks
 
 <a name="osx"></a>
 ### OS X ###
-1. Download [ShadowsocksX](/mirror/#shadowsocks).
+1. Download [ShadowsocksX-NG](/mirror/#shadowsocks).
 1. Double-click the DMG, and drag the icon into your Applications folder.
-1. Launch ShadowsocksX. You will be prompted to enter your password so that your system proxy settings can be modified.
+1. Launch ShadowsocksX-NG. You will be prompted to enter your password so that your system proxy settings can be modified.
 1. Look for the Shadowsocks paper plane icon in your menu bar and click on it.
 1. Make sure the QR code below is centered and completely visible, and choose *Scan QR Code from Screen...*
 
@@ -38,6 +38,7 @@ Shadowsocks
    1. Enter `{{ streisand_ipv4_address }}` and `{{ shadowsocks_server_port }}` in the *Address* fields.
    1. Make sure `{{ shadowsocks_encryption_method }}` is selected for the *Encryption* value.
    1. Enter `{{ shadowsocks_password.stdout }}` as the *Password*.
+   1. Checked `Enable OTA`.
    1. Click *OK*.
 1. Click on the Shadowsocks icon in the menu bar again, and choose *Global Mode*.
 1. You can use the Shadowsocks icon to enable/disable the VPN. The color of the icon will change based on whether or not it is active.

--- a/playbooks/roles/streisand-mirror/templates/mirror-index.md.j2
+++ b/playbooks/roles/streisand-mirror/templates/mirror-index.md.j2
@@ -59,6 +59,11 @@ The files mirrored below have all been cryptographically verified. Where possibl
 * [{{ shadowsocks_x_filename }}]({{ shadowsocks_x_href }})
   * Checksum: *{{ shadowsocks_x_checksum }}*
 
+**OS X 10.10+**
+
+* [{{ shadowsocks_x_ng_filename }}]({{ shadowsocks_x_ng_href }})
+  * Checksum: *{{ shadowsocks_x_ng_checksum }}*
+
 **Windows**
 
 * [{{ shadowsocks_gui_filename }}]({{ shadowsocks_gui_href }})

--- a/playbooks/roles/streisand-mirror/vars/shadowsocks.yml
+++ b/playbooks/roles/streisand-mirror/vars/shadowsocks.yml
@@ -25,6 +25,12 @@ shadowsocks_x_href: "{{ shadowsocks_mirror_href_base }}/{{ shadowsocks_x_filenam
 shadowsocks_x_url: "https://github.com/shadowsocks/shadowsocks-iOS/releases/download/{{ shadowsocks_x_version }}/{{ shadowsocks_x_filename }}"
 shadowsocks_x_checksum: "sha256:f0e263dd1d74b0b6977389f2b8b28c524bceccbc5ad24ca8a8164b92ede1c45a"
 
+shadowsocks_x_ng_version: "1.2"
+shadowsocks_x_ng_filename: "ShadowsocksX-NG-{{ shadowsocks_x_ng_version }}.dmg"
+shadowsocks_x_ng_href: "{{ shadowsocks_mirror_href_base }}/{{ shadowsocks_x_ng_filename }}"
+shadowsocks_x_ng_url: "https://github.com/shadowsocks/ShadowsocksX-NG/releases/download/{{ shadowsocks_x_ng_version }}/{{ shadowsocks_x_ng_filename }}"
+shadowsocks_x_ng_checksum: "sha256:c9565a8af063c73bf3fc112f6501fe08931c63631d51910c33372db736ec5c45"
+
 # Linux
 shadowsocks_python_version: "2.8.2"
 shadowsocks_python_filename: "shadowsocks-{{ shadowsocks_python_version }}.tar.gz"
@@ -36,4 +42,5 @@ shadowsocks_download_urls:
   - { url: "{{ shadowsocks_android_url }}", checksum: "{{ shadowsocks_android_checksum }}" }
   - { url: "{{ shadowsocks_gui_url }}",     checksum: "{{ shadowsocks_gui_checksum }}" }
   - { url: "{{ shadowsocks_x_url }}",       checksum: "{{ shadowsocks_x_checksum }}" }
+  - { url: "{{ shadowsocks_x_ng_url }}",       checksum: "{{ shadowsocks_x_ng_checksum }}" }
   - { url: "{{ shadowsocks_python_url }}",  checksum: "{{ shadowsocks_python_checksum }}" }


### PR DESCRIPTION
OSX client ShadowsocksX-NG is now recommended on [shadowsocks.org](https://shadowsocks.org/en/download/clients.html).
However, [it require OSX 10.10+](https://github.com/shadowsocks/ShadowsocksX-NG/releases)