### PR TITLE
Don't install xmlto recommends. Fixes #404

### DIFF
--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Install the Libreswan dependencies that are required for compilation
   apt:
     name: "{{ item }}"
+    install_recommends: "{{ 'yes' if item == 'xmlto' else 'no' }}"
   with_items: "{{ libreswan_compilation_dependencies }}"
 
 - name: Install xl2tpd


### PR DESCRIPTION
xmlto recommends includes `dblatex` which in turn installs `latex` - a huge dependency.