### PR TITLE
apt-transport-https

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -27,6 +27,8 @@ streisand_common_packages:
   # Word List dictionary used by several roles to generate random
   # (yet typeable!) passphrases
   - wamerican-huge
+  # Ensuring this is installed as some cloud providers don't install by default
+  - apt-transport-https
 
 streisand_gateway_location: "/var/www/streisand"
 


### PR DESCRIPTION
Ensures that apt-transport-https is installed as some cloud providers don't image their distros with it installed by default. Addresses #407