### PR TITLE
Document using ansible_user in inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ You can also run Streisand on any number of new Ubuntu 16.04 servers. Dedicated 
 
     ansible-playbook playbooks/streisand.yml
 
-The servers should be accessible using SSH keys, and *root* is used as the connecting user by default (though this is simple to change by updating the streisand.yml file or ansible.cfg file).
+The servers should be accessible using SSH keys, and *root* is used as the connecting user by default (though this is simple to change while editing the inventory file).
 
 Upcoming Features
 -----------------

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,11 +1,6 @@
 [defaults]
 inventory = inventory
 
-# Enables privilege escalation by default, which can be helpful if a
-# different value is chosen for the `remote_user` directive in the
-# primary streisand.yml playbook.
-become = True
-
 # This is a convenient setting for a brand-new Streisand server that
 # you are connecting to for the first time. However, this line should be
 # commented out if you are connecting to an existing server where a

--- a/inventory
+++ b/inventory
@@ -15,3 +15,10 @@ localhost ansible_python_interpreter=python
 #
 # [streisand-host]
 # 255.255.255.255
+#
+# If the SSH user to be used to login is not "root", specify it here with
+# the ansible_user directive. Streisand will sudo automatically. If sudo
+# requires a password, use the --ask-become-pass command line option.
+#
+# [streisand-host]
+# 255.255.255.255 ansible_user=ubuntu

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -4,6 +4,7 @@
   gather_facts: no
 
   remote_user: root
+  become: true
 
   tasks:
     - name: Install Python using a raw SSH command to enable the execution of Ansible modules
@@ -17,6 +18,7 @@
   hosts: streisand-host
 
   remote_user: root
+  become: true
 
   roles:
     - common


### PR DESCRIPTION
Also, moved the become directive to the playbook. While it should work
correctly from ansible.cfg, it didn't in my tests.