### PR TITLE
Create and reference streisand-users mailing list

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Services Provided
 
 Installation
 ------------
-Please read all installation instructions **carefully** before proceeding.
+Please read all installation instructions **carefully** before proceeding. If you have questions or issues regarding the installation process, please create a topic on the [streisand-users](https://groups.google.com/forum/#!forum/streisand-users/) mailing list.
 
 ### Important Clarification ###
 Streisand is based on [Ansible](http://www.ansible.com/home), an automation tool that is typically used to provision and configure files and packages on remote servers. That means when you run Streisand, it automatically sets up **another remote server** with the VPN packages and configuration.


### PR DESCRIPTION
There is a lot of chatter within the Github issues for things like
troubleshooting connectivity and basic installation questions which
would be better suited for a mailing list.

I took the liberty of creating a list on Google Groups and adding it
to the documentation here. The idea is that this will reduce clutter
in the Github issues (which should arguably be only code-related issues)
and provide users with a way to discuss non-code issues.

@jlund If you accept this, shoot me an email and I'll get you set up as an admin on the mailing list.
