### PR TITLE
`pycurl required for this module` error on OS X also

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ Complete all of these tasks on your local home machine.
   * On OS X
 
             sudo easy_install pip
+            sudo pip install pycurl
+            
 * Install [Ansible](http://www.ansible.com/home).
   * On OS X (via [Homebrew](http://brew.sh/))
 


### PR DESCRIPTION
Similar to this commit for issue #203: https://github.com/jlund/streisand/commit/9709cd2e09966cf1cad3484bb4b66d18b274ed48

Error message:

```
TASK [genesis-linode : Create the server] **************************************
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "pycurl required for this module"}
```

I'm on OS X v10.9.5.