### PR TITLE
Update monitrc.j2: don't monitor for non-installed softwares

### DIFF
--- a/playbooks/roles/monit/templates/monitrc.j2
+++ b/playbooks/roles/monit/templates/monitrc.j2
@@ -25,6 +25,7 @@ check process nginx with pidfile /var/run/nginx.pid
 check process vpn-network with pidfile /var/run/openvpn/server.pid
    start program = "/etc/init.d/openvpn start server"
    stop program = "/etc/init.d/openvpn stop server"
+   depends on openvpn-installed
 
 check host tap0 with address 10.8.0.1
     start program = "/etc/init.d/openvpn start server"
@@ -32,10 +33,12 @@ check host tap0 with address 10.8.0.1
     if failed
         icmp type echo count 5 with timeout 15 seconds
     then restart
+    depends on openvpn-installed
 
 check process vpn-network-udp with pidfile /var/run/openvpn/server-udp.pid
    start program = "/etc/init.d/openvpn start server-udp"
    stop program = "/etc/init.d/openvpn stop server-udp"
+   depends on openvpn-installed
 
 check host tap1 with address 10.9.0.1
     start program = "/etc/init.d/openvpn start server-udp"
@@ -43,6 +46,10 @@ check host tap1 with address 10.9.0.1
     if failed
         icmp type echo count 5 with timeout 15 seconds
     then restart
+    depends on openvpn-installed
+
+check file openvpn-installed with path /etc/init.d/openvpn
+   if does not exist then unmonitor
 
 
 # OpenSSH
@@ -57,8 +64,12 @@ check process sshd with pidfile /var/run/sshd.pid
 check process stunnel4 with pidfile /var/run/stunnel4.pid
 	start program = "/etc/init.d/stunnel4 start" with timeout 20 seconds
 	stop program = "/etc/init.d/stunnel4 stop"
-	if failed host 127.0.0.1 port {{ stunnel_remote_port }} with timeout 20 seconds then restart
+	if failed host 127.0.0.1 port {{ stunnel_remote_port | default("993") }} with timeout 20 seconds then restart
 	if 3 restarts within 5 cycles then unmonitor
+	depends on stunnel-installed
+
+check file stunnel-installed with path /etc/init.d/stunnel4
+   if does not exist then unmonitor
 
 
 # dnsmasq
@@ -76,6 +87,7 @@ check process dnsmasq with pidfile /var/run/dnsmasq/dnsmasq.pid
   depends on dnsmasq-hosts
 
 check file dnsmasq-bin with path /usr/sbin/dnsmasq
+   if does not exist then unmonitor
    if failed checksum then unmonitor
    if failed permission 755 then unmonitor
    if failed uid root then unmonitor


### PR DESCRIPTION
The final goal is that we are able to choose what services will be installed by streisand, with arbitrary  combination.