### PR TITLE
Uses default values in template to avoid "undefined variable" errors

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/firewall.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/firewall.md.j2
@@ -12,19 +12,19 @@ If you are installing Streisand on an existing server or alternate provider then
 * Nginx (Streisand Gateway)
   * TCP - {{ nginx_port }}
 * OpenConnect / Cisco AnyConnect
-  * TCP - {{ ocserv_port }}
-  * UDP - {{ ocserv_port }}
+  * TCP - {{ ocserv_port | default(4443) }}
+  * UDP - {{ ocserv_port | default(4443) }}
 * OpenSSH
   * TCP - {{ ssh_port }}
 * OpenVPN
   * UDP - 53 to/from `10.8.0.1`
     * This is the address that OpenVPN binds to on the virtual TUN interface that it creates. Dnsmasq listens for DNS traffic on this port and responds to requests from connected OpenVPN clients.
-  * TCP - {{ openvpn_port }}
-  * UDP - {{ openvpn_port_udp }}
+  * TCP - {{ openvpn_port | default(636) }}
+  * UDP - {{ openvpn_port_udp | default(8757) }}
 * Shadowsocks
-  * TCP - {{ shadowsocks_server_port }}
+  * TCP - {{ shadowsocks_server_port | default(8530) }}
 * stunnel
-  * TCP - {{ stunnel_remote_port }}
+  * TCP - {{ stunnel_remote_port | default(993) }}
 * Tor
-  * TCP - {{ tor_orport }} - Bridge
-  * TCP - {{ tor_obfs4_port }} - obfs4 pluggable transport
+  * TCP - {{ tor_orport | default(8443) }} - Bridge
+  * TCP - {{ tor_obfs4_port | default(9443) }} - obfs4 pluggable transport

--- a/playbooks/roles/ufw/tasks/main.yml
+++ b/playbooks/roles/ufw/tasks/main.yml
@@ -52,7 +52,7 @@
 
 - name: Ensure UFW allows OpenConnect (ocserv)
   ufw:
-    to_port: "{{ ocserv_port }}"
+    to_port: "{{ ocserv_port | default(4443) }}"
     proto: "any"
     rule: "allow"
 
@@ -73,36 +73,36 @@
 
 - name: Ensure UFW allows OpenVPN
   ufw:
-    to_port: "{{ openvpn_port }}"
+    to_port: "{{ openvpn_port | default(636) }}"
     proto: "tcp"
     rule: "allow"
 
 - name: Ensure UFW allows OpenVPN over UDP
   ufw:
-    to_port: "{{ openvpn_port_udp }}"
+    to_port: "{{ openvpn_port_udp | default(8757) }}"
     proto: "udp"
     rule: "allow"
 
 - name: Ensure UFW allows Shadowsocks
   ufw:
-    to_port: "{{ shadowsocks_server_port }}"
+    to_port: "{{ shadowsocks_server_port | default(8530) }}"
     proto: "tcp"
     rule: "allow"
 
 - name: Ensure UFW allows stunnel
   ufw:
-    to_port: "{{ stunnel_remote_port }}"
+    to_port: "{{ stunnel_remote_port | default(993) }}"
     proto: "tcp"
     rule: "allow"
 
 - name: Ensure UFW allows Tor bridge
   ufw:
-    to_port: "{{ tor_orport }}"
+    to_port: "{{ tor_orport | default(8443) }}"
     proto: "tcp"
     rule: "allow"
 
 - name: Ensure UFW allows Tor obfs4 pluggable transport
   ufw:
-    to_port: "{{ tor_obfs4_port }}"
+    to_port: "{{ tor_obfs4_port | default(9443) }}"
     proto: "tcp"
     rule: "allow"


### PR DESCRIPTION
The goal is same to #452. If we commented out openvpn in streisand.yml for example, variables defined in `playbooks/roles/openvpn/defaults/main.yml` are unable to be accessed by other roles. Adding the `default` filter can avoid runtime errors, though it is quite ugly. @jlund if you don't like this solution, could you give me some suggestions?