### PR TITLE
Removed ike_port, ipsec_port and l2tp_port variables

### DIFF
--- a/playbooks/roles/ec2-security-group/tasks/main.yml
+++ b/playbooks/roles/ec2-security-group/tasks/main.yml
@@ -30,16 +30,16 @@
       # L2TP/IPsec
       # ---
       - proto: udp
-        from_port: "{{ ike_port }}"
-        to_port: "{{ ike_port }}"
+        from_port: "500"
+        to_port: "500"
         cidr_ip: 0.0.0.0/0
       - proto: udp
-        from_port: "{{ ipsec_port }}"
-        to_port: "{{ ipsec_port }}"
+        from_port: "4500"
+        to_port: "4500"
         cidr_ip: 0.0.0.0/0
       - proto: udp
-        from_port: "{{ l2tp_port }}"
-        to_port: "{{ l2tp_port }}"
+        from_port: "1701"
+        to_port: "1701"
         cidr_ip: 0.0.0.0/0
       # OpenConnect (ocserv)
       # ---

--- a/playbooks/roles/gce-network/tasks/main.yml
+++ b/playbooks/roles/gce-network/tasks/main.yml
@@ -56,7 +56,7 @@
   gce_net:
     name: "{{ gce_network }}"
     fwname: "streisand-{{ gce_server_name }}-l2tp-ipsec"
-    allowed: "udp:{{ ike_port }},{{ ipsec_port }},{{ l2tp_port }}"
+    allowed: "udp:500,4500,1701"
     state: "present"
     src_range: 0.0.0.0/0
     service_account_email: "{{ gce_service_account_email }}"

--- a/playbooks/roles/l2tp-ipsec/defaults/main.yml
+++ b/playbooks/roles/l2tp-ipsec/defaults/main.yml
@@ -1,4 +1,1 @@
 ---
-ike_port: 500
-ipsec_port: 4500
-l2tp_port: 1701


### PR DESCRIPTION
Hi @DavidWittman, I'm trying to implement what you proposed in #453, to collect variables into a centralized place. However, I found that variables defined in `roles/l2tp-ipsec/defaults/main.yml` are totally useless. They are not actually "variable" since we can't change them to other values, and they had already been hardcoded in many place.

Removing them can eliminate fews "undefined variable" errors. Otherwise, we have to move them to the centralized place, but I think it will mislead users that those ports are customizable.