### PR TITLE
Added support for Ubuntu cloud-init status checking

### DIFF
--- a/playbooks/amazon.yml
+++ b/playbooks/amazon.yml
@@ -106,4 +106,5 @@
     - genesis-amazon
 
 
+- include: cloud-status.yml
 - include: streisand.yml

--- a/playbooks/cloud-status.yml
+++ b/playbooks/cloud-status.yml
@@ -10,7 +10,7 @@
 
   tasks:
     - name: Wait for cloud-init to complete
-      raw: bash -c "for i in {1..13}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
+      raw: bash -c "for i in {1..30}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
       register: result
       failed_when: result.rc != 0
 

--- a/playbooks/cloud-status.yml
+++ b/playbooks/cloud-status.yml
@@ -1,0 +1,17 @@
+- name: Checking instance status
+# =========================================
+  hosts: streisand-host
+  gather_facts: no
+
+  remote_user: root
+  become: true
+
+
+
+  tasks:
+    - name: Wait for cloud-init to complete
+      raw: bash -c "for i in {1..13}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
+      register: result
+      failed_when: result.rc != 0
+
+

--- a/playbooks/digitalocean.yml
+++ b/playbooks/digitalocean.yml
@@ -61,4 +61,5 @@
     - genesis-digitalocean
 
 
+- include: cloud-status.yml
 - include: streisand.yml

--- a/playbooks/google.yml
+++ b/playbooks/google.yml
@@ -103,4 +103,5 @@
     - genesis-google
 
 
+- include: cloud-status.yml
 - include: streisand.yml

--- a/playbooks/rackspace.yml
+++ b/playbooks/rackspace.yml
@@ -46,4 +46,5 @@
     - genesis-rackspace
 
 
+- include: cloud-status.yml
 - include: streisand.yml


### PR DESCRIPTION
Ubuntu cloud-init allows the execution of post-deployment tasks. Cloud-init is used or supported by Ubuntu images on the following providers that Streisand uses: Amazon, DigitalOcean, Rackspace, and Google. Linode does not install cloud-init on its Ubuntu images by default.

After the SSH connection is established, but before any roles are installed, this patch checks for the /var/lib/cloud/instance/boot-finished file, indicating all tasks performed by cloud-init have been completed. The check occurs every second for 30 seconds. If the file is not found within the timeout period, a fail is thrown and the deployment stops.

Since cloud-init tasks can impact Streisand, waiting for its completion avoids race conditions.

Fixes #457