### PR TITLE
UFW: open udp port for Shadowsocks.

### DIFF
--- a/playbooks/roles/ufw/tasks/main.yml
+++ b/playbooks/roles/ufw/tasks/main.yml
@@ -86,7 +86,7 @@
 - name: Ensure UFW allows Shadowsocks
   ufw:
     to_port: "{{ shadowsocks_server_port }}"
-    proto: "tcp"
+    proto: "any"
     rule: "allow"
 
 - name: Ensure UFW allows stunnel


### PR DESCRIPTION
As a result of GFW DNS spoofing. Most Shadowsocks users in China need to relay their DNS request via ss-tunnel.
Shadowsocks-libev official repository [enable this feature by default](https://github.com/shadowsocks/shadowsocks-libev/blob/master/debian/shadowsocks-libev.default#L18) on server-side. I thinks it's better to let UFW open the udp port for Shadowsocks.