### PR TITLE
workaround for ec2+boto+osx user. 

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,5 +1,5 @@
 [localhost]
-localhost ansible_python_interpreter=python
+localhost ansible_connection=local ansible_python_interpreter=python
 
 # Uncomment the following lines and update the IP address if you would
 # like to use Streisand to configure a server that is already running


### PR DESCRIPTION
Hi, 

As a OSX user having installed python without brew, I run into a ansible error:
`"msg": "boto required for this module"`

```
$- pip list boto | grep boto
boto (2.45.0)

```

I'm not familiar with ansible, but the osx/ansible community seams to have a semi-official workaround, described here: 
https://github.com/ansible/ansible/issues/15019

This pull request implement that workaround, if the inventory file should not change, that should be documented to point people in that direction. 

With the modification to inventory, I was able to spin up a server and connect to it. 

Thanks y'all for your work. 