### PR TITLE
Update OpenVPN instructions on Ubuntu

### DIFF
--- a/playbooks/roles/openvpn/templates/instructions.md.j2
+++ b/playbooks/roles/openvpn/templates/instructions.md.j2
@@ -99,6 +99,9 @@ It's preferable to configure Ubuntu using the OpenVPN plugin for NetworkManager.
 1. Click the *+* button in the lower-left of the window.
 1. Select *VPN* from the Interface drop-down and click *Create*.
 1. Select *OpenVPN* and click *Create*.
+  * If you don't see an *OpenVPN* option, install the following package:
+
+    `sudo agt-get install network-manager-openvpn-gnome`
 1. Enter `{{ streisand_server_name }}` for the *Connection name*.
 1. Enter `{{ openvpn_server }}` for the *Gateway*.
 1. Make sure *Certificates (TLS)* is selected for the *Type*.


### PR DESCRIPTION
Add a notice that users might need to install`network-manager-openvpn-gnome` in order to select *OpenVPN* as a VPN Connection Type.

(closes to #531)