### PR TITLE
Ensure the `streisand_server_name` variable does not get set to a value with whitespace characters

### DIFF
--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -99,7 +99,7 @@
 
 - name: Set the streisand_server_name variable
   set_fact:
-    streisand_server_name: "{{ aws_instance_name }}"
+    streisand_server_name: "{{ aws_instance_name | regex_replace('\\s', '_') }}"
 
 - name: New EC2 servers are occasionally slow to process incoming SSH connections even after the OpenSSH daemon has started up. Pause for 90 seconds.
   pause:

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -54,4 +54,4 @@
 
 - name: Set the streisand_server_name variable
   set_fact:
-    streisand_server_name: "{{ do_server_name }}"
+    streisand_server_name: "{{ do_server_name | regex_replace('\\s', '_') }}"

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -37,4 +37,4 @@
 
 - name: Set the streisand_server_name variable
   set_fact:
-    streisand_server_name: "{{ gce_server_name }}"
+    streisand_server_name: "{{ gce_server_name | regex_replace('\\s', '_') }}"

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -38,4 +38,4 @@
 
 - name: Set the streisand_server_name variable
   set_fact:
-    streisand_server_name: "{{ linode_server_name }}"
+    streisand_server_name: "{{ linode_server_name | regex_replace('\\s', '_') }}"

--- a/playbooks/roles/genesis-rackspace/tasks/main.yml
+++ b/playbooks/roles/genesis-rackspace/tasks/main.yml
@@ -30,4 +30,4 @@
 
 - name: Set the streisand_server_name variable
   set_fact:
-    streisand_server_name: "{{ rackspace_server_name }}"
+    streisand_server_name: "{{ rackspace_server_name | regex_replace('\\s', '_') }}"


### PR DESCRIPTION
This is a proposed accommodation for issue #548. The fix takes place at the end of each `gensis-*` role where the `streisand_server_name` fact is being set for the remainder of the playbook's execution.