### PR TITLE
fix: Documentation mispelling

### DIFF
--- a/playbooks/roles/ssh/files/sshd_config
+++ b/playbooks/roles/ssh/files/sshd_config
@@ -33,7 +33,7 @@ LogLevel QUIET
 # Ensure that logging is disabled for SFTP connections as well.
 Subsystem sftp  /usr/lib/openssh/sftp-server -f AUTHPRIV -l QUIET
 
-# Use kernel sandbox mechanisms where possible in unprivilegied processes
+# Use kernel sandbox mechanisms where possible in unprivileged processes
 # Systrace on OpenBSD, Seccomp on Linux, seatbelt on MacOSX/Darwin, rlimit elsewhere.
 UsePrivilegeSeparation sandbox
 


### PR DESCRIPTION
Happened to catch this as I was reading through the documentation :)