### PR TITLE
Update openconnect gui for windows

### DIFF
--- a/playbooks/roles/openconnect/templates/instructions.md.j2
+++ b/playbooks/roles/openconnect/templates/instructions.md.j2
@@ -17,7 +17,7 @@ OpenConnect is an extremely high-performance and lightweight VPN server that als
 1. Complete the TAP-Windows Setup Wizard.
    * Choose the default options, and allow the TAP driver from the OpenVPN project to be installed.
 1. Launch the OpenConnect application.
-1. Click the *Edit* icon (pencil and notepad).
+1. Click the *Edit* icon (gear) and select 'New profile advanced'.
 1. Enter `{{ streisand_server_name }}` for the *Name*.
 1. Enter `{{ streisand_ipv4_address }}:{{ ocserv_port }}` for the *Gateway*.
 1. Enter `streisand` for the *Username* and click *Save*.

--- a/playbooks/roles/streisand-mirror/vars/openconnect.yml
+++ b/playbooks/roles/streisand-mirror/vars/openconnect.yml
@@ -21,6 +21,9 @@ openconnect_windows_href: "{{ openconnect_mirror_href_base }}/{{ openconnect_win
 openconnect_windows_url: "https://github.com/openconnect/openconnect-gui/releases/download/{{ openconnect_windows_version }}/{{ openconnect_windows_filename }}"
 openconnect_windows_checksum: "sha256:65ea336108640b44eb16192c7d357953895ce9f61f5ee77d124e56e98714cc7e"
 
+# The below section is commented out as v1.5.1 OpenConnect GUI for macOS crashes on El Capitan when
+# attempting to connect.
+# see issue: https://github.com/openconnect/openconnect-gui/issues/160
 # macOS
 #openconnect_macos_version: "v1.5.1"
 #openconnect_macos_filename: "openconnect-gui-1.5.1-Darwin.dmg"

--- a/playbooks/roles/streisand-mirror/vars/openconnect.yml
+++ b/playbooks/roles/streisand-mirror/vars/openconnect.yml
@@ -15,12 +15,20 @@ openconnect_source_url: "https://d1shxn4vnb0yj3.cloudfront.net/{{ openconnect_so
 openconnect_source_checksum: "sha256:facf695368dc4537a6a30e2147be90b1d77ee3cb2d269eaef070b6d9ddab70f2"
 
 # Windows
-openconnect_windows_version: "v1.3"
-openconnect_windows_filename: "openconnect-installer.exe"
+openconnect_windows_version: "v1.5.1"
+openconnect_windows_filename: "openconnect-gui-1.5.1-win32.exe"
 openconnect_windows_href: "{{ openconnect_mirror_href_base }}/{{ openconnect_windows_filename }}"
 openconnect_windows_url: "https://github.com/openconnect/openconnect-gui/releases/download/{{ openconnect_windows_version }}/{{ openconnect_windows_filename }}"
-openconnect_windows_checksum: "sha256:894ce16fbfbb4be0f205dc5bc55323b5d99306e81672ad5d631bd9bab0d586b1"
+openconnect_windows_checksum: "sha256:65ea336108640b44eb16192c7d357953895ce9f61f5ee77d124e56e98714cc7e"
+
+# macOS
+#openconnect_macos_version: "v1.5.1"
+#openconnect_macos_filename: "openconnect-gui-1.5.1-Darwin.dmg"
+#openconnect_macos_href: "{{ openconnect_mirror_href_base }}/{{ openconnect_macos_filename }}"
+#openconnect_macos_url: "https://github.com/openconnect/openconnect-gui/releases/download/{{ openconnect_macos_version }}/{{ openconnect_macos_filename }}"
+#openconnect_macos_checksum: "sha256:b2c338cfe9d0725bee98893225449e27cf7e337d43b0f8b08aec96de6f761f08"
 
 openconnect_download_urls:
   - { url: "{{ openconnect_source_url }}",  checksum: "{{ openconnect_source_checksum }}" }
   - { url: "{{ openconnect_windows_url }}", checksum: "{{ openconnect_windows_checksum }}" }
+  #- { url: "{{ openconnect_macos_url }}", checksum: "{{ openconnect_macos_checksum }}" }


### PR DESCRIPTION
Updates OpenConnect GUI for Windows to v1.5.1

macOS portions were commented out due to an issue with the latest release that crashes on El Capitan, but can later be re-introduced easily once an new build is released.

Would appreciate a test on a Windows machine to verify that there are no issues.

Thanks!