### PR TITLE
linode: work around kernel limitation

### DIFF
--- a/monkey/usercustomize.py
+++ b/monkey/usercustomize.py
@@ -1,0 +1,10 @@
+try:
+    # Here we monkey patch the Linode avail_kernels function
+    # to always return "GRUB 2", so that we can use the
+    # distribution kernel, instead of the terrible Linode one.
+    import linode.api
+    def avail_kernels(arg):
+        return [ { 'LABEL': 'Latest 64', 'KERNELID': 210 } ]
+    linode.api.Api.avail_kernels = avail_kernels
+except ImportError:
+    pass

--- a/streisand
+++ b/streisand
@@ -29,6 +29,8 @@ echo -n "Which provider are you using?
   6. Rackspace
 : "
 
+export PYTHONPATH="$(cd "$(dirname "$0")" && pwd -P)/monkey:$PYTHONPATH"
+
 read reply
 
 case "$reply" in


### PR DESCRIPTION
Only in the next ansible version will we have support for setting Linode's kernels directly from our playbooks. Until then, we need to monkey patch around this limitation.

Fixes: #500
Fixes: #609