### PR TITLE
linode: hard code distro id

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,5 +1,5 @@
 [localhost]
-localhost ansible_connection=local ansible_python_interpreter=python
+localhost ansible_connection=local
 
 # Uncomment the following lines and update the IP address if you would
 # like to use Streisand to configure a server that is already running

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -3,19 +3,13 @@
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
 
-- name: Get the latest Ubuntu 16.04 image ID from the Linode API
-  shell: curl -s 'https://api.linode.com/?api_key={{ linode_api_key }}&api_action=avail.distributions' | {{ ansible_python_interpreter }} -c 'import json; import sys; j = json.loads(sys.stdin.read()); print [img for img in j["DATA"] if img["LABEL"]=="Ubuntu 16.04 LTS"][0]["DISTRIBUTIONID"]'
-  args:
-    warn: no
-  register: linode_ubuntu_distribution_id
-
 - name: Create the server
   linode:
     api_key: "{{ linode_api_key }}"
     name: "{{ linode_server_name }}"
     plan: "{{ linode_plan_id }}"
     datacenter: "{{ regions[linode_datacenter] }}"
-    distribution: "{{ linode_ubuntu_distribution_id.stdout }}"
+    distribution: "146"
     ssh_pub_key: "{{ ssh_key.stdout }}"
     wait: yes
   register: streisand_server


### PR DESCRIPTION
The use of ansible_python_interpreter isn't correct, because the given
python will not work on both version of python, so it breaks entirely,
on many distros unless a user manually edits inventory. Since Streisand
is mostly used by clueless users, this probably isn't a good situation.

Rather than fixing this problem, it occurs to me that elsewhere distro
ID constants are being hard coded (for, say, GRUB 2). Since Linode isn't
changing the IDs returned from their API anyway, it's much easier just
to hard code this. When we change distros, we'll change IDs.

This is much simpler and less error prone. I don't think we gained
anything from the prior abstraction anyway.