### PR TITLE
Workaround missing Linode kernel headers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 generated-docs
 *.retry
+*.pyc

--- a/playbooks/linode-headers.yml
+++ b/playbooks/linode-headers.yml
@@ -1,0 +1,23 @@
+#
+# Linode's grub2 image doesn't include kernel headers, which means the
+# wireguard-dkms package will fail to generate any kernel modules. We work
+# around this by doing the equivalent of a
+# `apt-get install linux-kernel-headers-$(uname -r)`.
+# It would be tempting to just install `linux-headers-generic` but in practice
+# this ends up installing different headers than the kernel that is running at
+# the time wireguard-dkms is installed following all the apt updates
+#
+- name: Install the Linode kernel headers
+  hosts: streisand-host
+  gather_facts: no
+  remote_user: "root"
+  become: true
+
+  tasks:
+    - name: Determine the running kernel version
+      command: uname -r
+      register: linode_kernel_version
+
+    - name: "Install linux-headers-{{ linode_kernel_version.stdout }} for Wireguard"
+      apt:
+        name: "linux-headers-{{ linode_kernel_version.stdout }}"

--- a/playbooks/linode.yml
+++ b/playbooks/linode.yml
@@ -49,5 +49,6 @@
   roles:
     - genesis-linode
 
+- include: linode-headers.yml
 
 - include: streisand.yml


### PR DESCRIPTION

Building on #612 3da8093 adds a workaround for Linode's grub2 instances
not having kernel headers installed. This manifests as the `wireguard-dkms`
package installing but generating no kernel modules. Later the systemctl task
will fail to bring the wg0-server interface up as a result.

This commit works around this by doing the equivalent of:
  `apt-get install linux-kernel-headers-$(uname -r)`
on the newly provisioned server, ensuring the kernel headers are there
for the wireguard role.

I've tested a from-scratch Linode provisioning and was able to configure a 
working wireguard client against a brand new Linode server once 3da8093
was applied. I believe this is the **last** hurdle for working Wireguard/Streisand
on Linode :tada: 