### PR TITLE
wireguard: explicitly install kernel headers for running kernel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 generated-docs
 *.retry
+*.pyc

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -1,4 +1,8 @@
 ---
+- name: Determine the running kernel release
+  command: uname -r
+  register: kernel_release
+
 - name: Add the WireGuard PPA
   apt_repository:
     repo: 'ppa:wireguard/wireguard'
@@ -7,6 +11,7 @@
   apt:
     name: "{{ item }}"
   with_items:
+    - linux-headers-{{ kernel_release.stdout }}
     - wireguard-dkms
     - wireguard-tools
 


### PR DESCRIPTION
An improvement on #615, this is necessary for providers like Linode and possibly others.

This hasn't actually been tested, so please somebody run it at least once before merging.