### PR TITLE
Restore `ansible_python_interpreter` inv var.

### DIFF
--- a/inventory
+++ b/inventory
@@ -1,5 +1,5 @@
 [localhost]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter=python
 
 # Uncomment the following lines and update the IP address if you would
 # like to use Streisand to configure a server that is already running


### PR DESCRIPTION
In 89f40e8 we revoved the `ansible_python_interpreter` on the assumption
it broke for many distros unless modified. This is likely still true,
but removing it also breaks OSX hosts that were previously working.

41f4f87 restores the `ansible_python_interpreter` var until a less
jarring fix can be worked out.