### PR TITLE
wireguard: always add generic headers

### DIFF
--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -12,6 +12,7 @@
     name: "{{ item }}"
   with_items:
     - linux-headers-{{ kernel_release.stdout }}
+    - linux-headers-generic
     - wireguard-dkms
     - wireguard-tools
 


### PR DESCRIPTION
After rebooting, we probably want to have the newer kernel headers available too.