### PR TITLE
Add basic Vagrantfile for local test instance.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 generated-docs
 *.retry
 *.pyc
+.vagrant/

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ generated-docs
 *.retry
 *.pyc
 .vagrant/
+ubuntu-xenial-16.04-cloudimg-console.log

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,6 +12,11 @@ Vagrant.configure(2) do |config|
       # NOTE: Uncomment the below line for verbose Ansible output
       # ansible.verbose = "v"
       ansible.playbook = "playbooks/streisand.yml"
+      ansible.host_vars = {
+        "streisand-host" => {
+          "noninteractive" => true
+        }
+      }
     end
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,17 @@
+Vagrant.require_version ">= 1.9.0"
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.define "streisand-host", primary: true do |streisand|
+    streisand.vm.hostname = "streisand-host"
+    streisand.vm.network :private_network, ip: "10.0.0.10"
+
+    streisand.vm.provision "ansible" do |ansible|
+      # NOTE: Uncomment the below line for verbose Ansible output
+      # ansible.verbose = "v"
+      ansible.playbook = "playbooks/streisand.yml"
+    end
+  end
+end

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -147,17 +147,20 @@
 
 - meta: flush_handlers
 
-- name: Success!
-  pause:
-    prompt: "Server setup is complete. The `{{ streisand_server_name }}.html` instructions file in the generated-docs folder is ready to give to friends, family members, and fellow activists. Press Enter to continue."
+- block:
+    - name: Success!
+      pause:
+        prompt: "Server setup is complete. The `{{ streisand_server_name }}.html` instructions file in the generated-docs folder is ready to give to friends, family members, and fellow activists. Press Enter to continue."
 
-- name: Attempt to open the instructions on Linux (if applicable). Errors in this task are ignored because the `xdg-open` command is not always available.
-  local_action: command xdg-open ../{{ streisand_local_directory }}/{{ streisand_server_name }}.html
-  ignore_errors: yes
-  when: hostvars['127.0.0.1']['ansible_system'] == "Linux"
+    - name: Attempt to open the instructions on Linux (if applicable). Errors in this task are ignored because the `xdg-open` command is not always available.
+      local_action: command xdg-open ../{{ streisand_local_directory }}/{{ streisand_server_name }}.html
+      ignore_errors: yes
+      when: hostvars['127.0.0.1']['ansible_system'] == "Linux"
+
+    - name: Open the instructions on OS X (if applicable)
+      local_action: command open ../{{ streisand_local_directory }}/{{ streisand_server_name }}.html
+      when: hostvars['127.0.0.1']['ansible_system'] == "Darwin"
+
+  when: noninteractive != "true"
   become: no
 
-- name: Open the instructions on OS X (if applicable)
-  local_action: command open ../{{ streisand_local_directory }}/{{ streisand_server_name }}.html
-  when: hostvars['127.0.0.1']['ansible_system'] == "Darwin"
-  become: no


### PR DESCRIPTION
b1987b6 adds a bare bones Vagrant file that will create
a `streisand-host` VM and provision it with the project playbooks.
Nothing fancy yet!

To use, install Vagrant & `vagrant up`.

f280e0f moves the streisand-gateway tasks related to pausing
execution, prompting for continuation, and opening the generated docs in
the host browser into an ansible block. The block has a condition
attached such that it only executes when the `noninteractive` var is
anything other than `"true"`.

The Vagrantfile is updated to provide `noninteractive = "true"` as a
host inventory variable to exploit this change. Now its possible to
`vagrant up` and have the command return without needing to use
a keydown to continue through the pause.