### PR TITLE
linode: abstract out the distribution id

### DIFF
--- a/playbooks/roles/genesis-linode/defaults/main.yml
+++ b/playbooks/roles/genesis-linode/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 linode_plan_id: 1
+linode_distribution_id: 146

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -9,7 +9,7 @@
     name: "{{ linode_server_name }}"
     plan: "{{ linode_plan_id }}"
     datacenter: "{{ regions[linode_datacenter] }}"
-    distribution: "146"
+    distribution: "{{ linode_distribution_id }}"
     ssh_pub_key: "{{ ssh_key.stdout }}"
     wait: yes
   register: streisand_server


### PR DESCRIPTION
This keeps things consistent.