### PR TITLE
wireguard: automatically set MTU from default route

### DIFF
--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -5,7 +5,7 @@ Address = 10.192.122.2/32
 #
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
-PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x
+PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x; linkMTU=$(ip link show $(ip route show default | sed -n 's/^default via .* \(dev [a-z0-9]\+\).*/\1/p' || true) | sed -n 's/.*mtu \([0-9]\+\).*/\1/p' || true); ip link set mtu $(( ${linkMTU:-1500} - 60 )) dev %i
 PostDown = resolvconf -d %i
 PrivateKey = {{ wireguard_client_private_key }}
 PresharedKey = {{ wireguard_preshared_key }}

--- a/playbooks/roles/wireguard/templates/wg0-server.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-server.conf.j2
@@ -4,6 +4,7 @@ SaveConfig = true
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wireguard_server_private_key }}
 PresharedKey = {{ wireguard_preshared_key }}
+PostUp = linkMTU=$(ip link show $(ip route show default | sed -n 's/^default via .* \(dev [a-z0-9]\+\).*/\1/p' || true) | sed -n 's/.*mtu \([0-9]\+\).*/\1/p' || true); ip link set mtu $(( ${linkMTU:-1500} - 60 )) dev %i
 
 [Peer]
 PublicKey = {{ wireguard_client_public_key }}


### PR DESCRIPTION
This is needed for some strange providers who give non-standard MTUs.
This is fairly rare on the client side, but on the server side, Google
Cloud Platform gives 1460, presumably due to vxlan or some other SDN
they deploy.

Also, while we're at it, since Streisand doesn't support IPv6 at the
moment (even though WireGuard does), we can get an extra 20 bytes in our
MTU by subtracting 60 instead of 80.

**I haven't tested this commit, so please make sure this actually works before merging.**