### PR TITLE
Retrieve the Libreswan source code from a CloudFront mirror location.

### DIFF
--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -15,7 +15,10 @@
 
 - name: Retrieve the Libreswan source code
   get_url:
-    url: https://download.libreswan.org/{{ libreswan_source_filename }}
+    # This CDN mirrors the Libreswan source code, and helps
+    # mitigate connection errors that were occurring when
+    # using the project's official download location.
+    url: https://d25kfp60e9u1dw.cloudfront.net/{{ libreswan_source_filename }}
     dest: "{{ libreswan_source_location }}"
     checksum: "{{ libreswan_checksum }}"
     owner: root


### PR DESCRIPTION
This mitigates sporadic "Hostname mismatch" errors on the official download location that appear to be related to SNI.