### PR TITLE
Update torrc.j2

### DIFF
--- a/playbooks/roles/tor-bridge/templates/torrc.j2
+++ b/playbooks/roles/tor-bridge/templates/torrc.j2
@@ -2,6 +2,7 @@ SocksPort 0
 ORPort {{ tor_orport }}
 ExtORPort auto
 BridgeRelay 1
+PublishServerDescriptor 0
 ExitPolicy reject *:*
 
 Nickname {{ tor_bridge_nickname.stdout }}


### PR DESCRIPTION
In this case "private" means that the bridge is configured with the option PublishServerDescriptor 0.  Without this option set, The Tor Project can learn about the bridge and may distribute its address to others.
https://www.whonix.org/wiki/Bridges#Additional_Information_and_Recommendations