### PR TITLE
Upgrade shadowsocks-libev to 3.0.6.

### DIFF
--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -18,8 +18,8 @@ shadowsocks_dependencies:
   # Shadowsocks may complain about lack of entropy without rng-tools installed
   - rng-tools
 
-shadowsocks_checksum: "sha256:961ddbe06c2fd6299d0f181a371af16463d59e146228c53769f24e08a1d95f2e"
-shadowsocks_version: "3.0.5"
+shadowsocks_checksum: "sha256:7d9b43b0235a57c115bfe160efd54abef96bffcbfff61c5496e7c2800f0734ca"
+shadowsocks_version: "3.0.6"
 shadowsocks_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ shadowsocks_version }}"
 shadowsocks_source_filename: "shadowsocks-libev-{{ shadowsocks_version }}.tar.gz"
 shadowsocks_source_location: "/usr/local/src/{{ shadowsocks_source_filename }}"


### PR DESCRIPTION
7019b4b upgrades shadowsocks-libev from 3.0.5 to 3.0.6. Most notably
this version fixes an AEAD related bug affecting the latest shadowrocket
iOS app.

Resolves #650 