### PR TITLE
Updates REQUIRED_ANSIBLE_VERSION to 2.3.0.0

### DIFF
--- a/streisand
+++ b/streisand
@@ -3,7 +3,7 @@
 
 set -e
 
-REQUIRED_ANSIBLE_VERSION="2.2.1.0"
+REQUIRED_ANSIBLE_VERSION="2.3.0.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 
 echo -e "\n\033[38;5;255m\033[48;5;234m\033[1m  S T R E I S A N D  \033[0m\n"


### PR DESCRIPTION
Having discussed this with other maintainers it sounds like bumping the REQUIRED_ANSIBLE_VERSION that the streisand wrapper checks is fairly painless since its generally easy for folks to update their Ansible installs to the latest via pip/etc.

With that in mind this PR bumps the REQUIRED_ANSIBLE_VERSION to 2.3.0.0 ahead of using some of the features it provides. It seems prudent to keep this process fluid by doing it frequently.