### PR TITLE
Update the Shadowsocks instructions to remove the Potatso AEAD warning.

### DIFF
--- a/playbooks/roles/shadowsocks/templates/instructions.md.j2
+++ b/playbooks/roles/shadowsocks/templates/instructions.md.j2
@@ -104,9 +104,6 @@ This should return a 301 Found response **not** a connection refused error.
 
 <a name="ios"></a>
 ### iOS ###
-
-**Note**: The Potatso iOS client **does not yet support [AEAD ciphers](https://shadowsocks.org/en/spec/AEAD-Ciphers.html)** and can not be used with the modern Streisand shadowsocks-libev server configuration.
-
 1. Download [Shadowrocket](https://itunes.apple.com/us/app/shadowrocket/id932747118?mt=8) and launch it.
 1. Tap the QR code import icon in the top-left of the screen.
 1. Use your phone to scan this image, or if you are using your phone _right now_ you can manually add a new proxy by tapping *Add Server* and using the information from the Linux section above:


### PR DESCRIPTION
New versions of Potatso 2 now support AEAD ciphers.