### PR TITLE
changes playbooks to use/modify DO_API_TOKEN

### DIFF
--- a/playbooks/digitalocean.yml
+++ b/playbooks/digitalocean.yml
@@ -46,7 +46,7 @@
       private: no
 
     - name: "do_access_token_entry"
-      prompt: "\n\nNew API access tokens can be generated in the DigitalOcean control panel.\nhttps://cloud.digitalocean.com/settings/applications\n  * When generating a new token, please note that the Write Scope is necessary\n    in order to create Droplets.\n\nIf this field is left blank, the environment variable DIGITALOCEAN_API_KEY\nwill be used.\n\nWhat is your DigitalOcean Access Token?\n"
+      prompt: "\n\nNew API access tokens can be generated in the DigitalOcean control panel.\nhttps://cloud.digitalocean.com/settings/applications\n  * When generating a new token, please note that the Write Scope is necessary\n    in order to create Droplets.\n\nIf this field is left blank, the environment variable DO_API_KEY\nwill be used.\n\nWhat is your DigitalOcean Access Token?\n"
       private: no
 
     - name: "do_ssh_name"

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Set the DigitalOcean Access Token fact to the value that was entered, or attempt to retrieve it from the environment if the entry is blank
   set_fact:
-    do_access_token: "{{ do_access_token_entry | default( lookup('env', 'DIGITALOCEAN_API_KEY') ) }}"
+    do_access_token: "{{ do_access_token_entry | default( lookup('env', 'DO_API_KEY') ) }}"
 
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub


### PR DESCRIPTION
When running streisand this morning, I noticed that it did not work with Digital Ocean.  Upon running the breaking playbook with -vvv, I saw the following error:

```
fatal: [localhost]: FAILED! => {
    "changed": false,
    "failed": true,
    "invocation": {
        "module_args": {
            "api_token": "",
            "backups_enabled": false,
            "command": "ssh",
            "id": null,
            "image_id": null,
            "ipv6": false,
            "name": "streisand",
            "private_networking": false,
            "region_id": null,
            "size_id": null,
            "ssh_key_ids": null,
            "ssh_pub_key": "<JUST MY PUBKEY>",
            "state": "present",
            "unique_name": false,
            "user_data": null,
            "virtio": true,
            "wait": true,
            "wait_timeout": 300
        }
    },
    "msg": "Unable to load DO_API_TOKEN"
}
```

The messaging and expected env vars in master both refer to DIGITALOCEAN_API_TOKEN, so I changed the messaging and the name of the env var ansible is looking for.