### PR TITLE
checks for pyenv before checking ansible

### DIFF
--- a/streisand
+++ b/streisand
@@ -3,6 +3,10 @@
 
 set -e
 
+if command -v pyenv &>/dev/null; then
+  eval "$(pyenv init - bash)";
+fi;
+
 REQUIRED_ANSIBLE_VERSION="2.3.0"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd -P)"
 


### PR DESCRIPTION
This is maybe too much of an edge case based on the intended audience, but I run pyenv and streisand would error out on searching for ansible because the pyenv env vars were not being set for the script.  This simply runs `pyenv init` if he `pyenv` command exists in the path.