### PR TITLE
wg-quick now figures out MTU on its own

### DIFF
--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -5,7 +5,7 @@ Address = 10.192.122.2/32
 #
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
-PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x; linkMTU=$(ip link show $(ip route show default | sed -n 's/^default via .* \(dev [a-z0-9]\+\).*/\1/p' || true) | sed -n 's/.*mtu \([0-9]\+\).*/\1/p' || true); ip link set mtu $(( ${linkMTU:-1500} - 60 )) dev %i
+PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x
 PostDown = resolvconf -d %i
 PrivateKey = {{ wireguard_client_private_key }}
 PresharedKey = {{ wireguard_preshared_key }}

--- a/playbooks/roles/wireguard/templates/wg0-server.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-server.conf.j2
@@ -4,7 +4,6 @@ SaveConfig = true
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wireguard_server_private_key }}
 PresharedKey = {{ wireguard_preshared_key }}
-PostUp = linkMTU=$(ip link show $(ip route show default | sed -n 's/^default via .* \(dev [a-z0-9]\+\).*/\1/p' || true) | sed -n 's/.*mtu \([0-9]\+\).*/\1/p' || true); ip link set mtu $(( ${linkMTU:-1500} - 60 )) dev %i
 
 [Peer]
 PublicKey = {{ wireguard_client_public_key }}


### PR DESCRIPTION
The latest wg-quick does this part automatically, so we no longer need this.

This reverts commit 945f9b0f057211d64cdc725ef1b55bc98ba9ffa1.

Please merge this after EggieCode/wireguard-ppa#18 is closed.