### PR TITLE
Set the streisand_noninteractive variable outside of Vagrant too.

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -6,3 +6,4 @@ upstream_dns_servers:
 streisand_ci: no
 
 streisand_client_test: no
+streisand_noninteractive: no

--- a/tests/group_vars/all/all
+++ b/tests/group_vars/all/all
@@ -2,6 +2,7 @@
 streisand_ci: true
 
 streisand_client_test: false
+streisand_noninteractive: no
 
 upstream_dns_servers:
   - 8.8.8.8


### PR DESCRIPTION
Fixes the conditional check in the block that opens the instructions when setup is finished.