### PR TITLE
WireGuard - Move the pre-shared key field to the Peer section.

### DIFF
--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -8,9 +8,9 @@ Address = 10.192.122.2/32
 PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x
 PostDown = resolvconf -d %i
 PrivateKey = {{ wireguard_client_private_key }}
-PresharedKey = {{ wireguard_preshared_key }}
 
 [Peer]
 PublicKey = {{ wireguard_server_public_key }}
+PresharedKey = {{ wireguard_preshared_key }}
 AllowedIPs = 0.0.0.0/0
 Endpoint = {{ streisand_ipv4_address }}:{{ wireguard_port }}

--- a/playbooks/roles/wireguard/templates/wg0-server.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-server.conf.j2
@@ -3,8 +3,8 @@ Address = 10.192.122.1/24
 SaveConfig = true
 ListenPort = {{ wireguard_port }}
 PrivateKey = {{ wireguard_server_private_key }}
-PresharedKey = {{ wireguard_preshared_key }}
 
 [Peer]
 PublicKey = {{ wireguard_client_public_key }}
+PresharedKey = {{ wireguard_preshared_key }}
 AllowedIPs = 10.192.122.2/32


### PR DESCRIPTION
This brings the client and server config files into alignment with the protocol changes and improvements that were made in the latest WireGuard snapshot (0.0.20170517):

https://lists.zx2c4.com/pipermail/wireguard/2017-May/001334.html