### PR TITLE
wireguard: preshared keys aren't useful here

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Services Provided
 * [unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates)
   * Your Streisand server is configured to automatically install new security updates.
 * [WireGuard](https://www.wireguard.io/)
-  * Linux users can take advantage of this next-gen, simple, kernel-based, state-of-the-art VPN that also happens to be ridiculously fast.
-  * In addition to the public-key crypto that WireGuard uses by default, a pre-shared key is also configured to help provide post-quantum resistance. Use the VPN of the future with an eye towards the future!
+  * Linux users can take advantage of this next-gen, simple, kernel-based, state-of-the-art VPN that also happens to be ridiculously fast and uses modern cryptographic principles that all other highspeed VPN solutions lack.
 
 Installation
 ------------

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -24,11 +24,6 @@
     - { private: "{{ wireguard_server_private_key_file }}", public: "{{ wireguard_server_public_key_file }}" }
     - { private: "{{ wireguard_client_private_key_file }}", public: "{{ wireguard_client_public_key_file }}" }
 
-- name: Generate a pre-shared key
-  shell: umask 077; wg genpsk > {{ wireguard_preshared_key_file }}
-  args:
-    creates: "{{ wireguard_preshared_key_file }}"
-
 - name: Register the key file contents
   command: cat {{ item }}
   register: wireguard_key_files
@@ -37,7 +32,6 @@
     - "{{ wireguard_client_public_key_file }}"
     - "{{ wireguard_server_private_key_file }}"
     - "{{ wireguard_server_public_key_file }}"
-    - "{{ wireguard_preshared_key_file }}"
 
 - name: Set the key material facts
   set_fact:
@@ -45,7 +39,6 @@
     wireguard_client_public_key:  "{{ wireguard_key_files.results[1].stdout }}"
     wireguard_server_private_key: "{{ wireguard_key_files.results[2].stdout }}"
     wireguard_server_public_key:  "{{ wireguard_key_files.results[3].stdout }}"
-    wireguard_preshared_key:      "{{ wireguard_key_files.results[4].stdout }}"
 
 - name: Generate the client and server configuration files
   template:

--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -11,6 +11,5 @@ PrivateKey = {{ wireguard_client_private_key }}
 
 [Peer]
 PublicKey = {{ wireguard_server_public_key }}
-PresharedKey = {{ wireguard_preshared_key }}
 AllowedIPs = 0.0.0.0/0
 Endpoint = {{ streisand_ipv4_address }}:{{ wireguard_port }}

--- a/playbooks/roles/wireguard/templates/wg0-server.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-server.conf.j2
@@ -6,5 +6,4 @@ PrivateKey = {{ wireguard_server_private_key }}
 
 [Peer]
 PublicKey = {{ wireguard_client_public_key }}
-PresharedKey = {{ wireguard_preshared_key }}
 AllowedIPs = 10.192.122.2/32

--- a/playbooks/roles/wireguard/vars/main.yml
+++ b/playbooks/roles/wireguard/vars/main.yml
@@ -4,7 +4,6 @@ wireguard_client_private_key_file: "{{ wireguard_path }}/client.key"
 wireguard_client_public_key_file:  "{{ wireguard_path }}/client.pub"
 wireguard_server_private_key_file: "{{ wireguard_path }}/server.key"
 wireguard_server_public_key_file:  "{{ wireguard_path }}/server.pub"
-wireguard_preshared_key_file:      "{{ wireguard_path }}/preshared.key"
 
 wireguard_firewall_rules:
   - iptables -A FORWARD -s 10.192.122.0/24 -j ACCEPT


### PR DESCRIPTION
Since Streisand is deployed over the internet through a non PQ-secure
mechanism, the preshared key mechanism isn't really useful, so just
don't configure it.