### PR TITLE
Work around `resolvconf` non-zero exit in wg client PostUp.

### DIFF
--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -5,7 +5,12 @@ Address = 10.192.122.2/32
 #
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
-PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x
+#
+# Note: You may see messages about "Failed to try-restart" services that you do
+# not have installed after the `resolvconf` PostUp. This is a side effect of the
+# `openresolv` package installed by the WireGuard PPA to provide the
+# `resolvconf` command and can be ignored.
+PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x || true
 PostDown = resolvconf -d %i
 PrivateKey = {{ wireguard_client_private_key }}
 


### PR DESCRIPTION
The Wireguard `wg0-client.conf` template contains a `PostUp` hook that
uses `resolvconf` to set the DNS server for the client. On Ubuntu
clients, the `openresolv` package that the Wireguard PPA depends on to
provide the `resolvconf` command has an interesting "quirk" where it
will try to restart network services that may not be installed. Since
these attempted restarts fail, the overall `resolvconf` command returns
a non-zero exit status. The `wg-quick` function that invokes the
`PostUp` handler, `execute_hook()`, considers a non-zero exit code for
a PostUp as a fatal error preventing the Wireguard interface from being
created successfully.

Interestingly, a subsequent attempt to bring up the interface with
`wg-quick` succeeds, likely because `openresolv` doesn't need to update
the DNS servers or restart dependent services because it already did so
on the first non-zero exit code invocation.

This commit applies a dirty hack by appending `|| true` to the `PostUp`
in the `wg0-client.conf` template after the `resolvconf` invocation.
This ignores any failures from this command which isn't ideal, but
allows the interface to come up on the first try for Ubuntu clients.