### PR TITLE
Default tor-bridge torrjc PublishServerDescriptor config to "0".

### DIFF
--- a/playbooks/roles/tor-bridge/defaults/main.yml
+++ b/playbooks/roles/tor-bridge/defaults/main.yml
@@ -1,3 +1,17 @@
 ---
 tor_orport: 8443
 tor_obfs4_port: 9443
+
+# By default Streisand does *not* publish the Tor relay's service descriptor to
+# the tor network. Using a value of 0 ensures the relay is private to the
+# streisand operator and their users. See the Tor documentation[0] for more
+# information:
+# [0]: https://www.torproject.org/docs/tor-manual.html.en#PublishServerDescriptor
+#
+tor_publish_service_desc: 0
+
+# If you would like to contribute to the overall health of the Tor network by
+# submitting your bridge relay for use by others comment out the
+# `tor_publish_service_desc: 0` line above and uncomment the following line:
+#
+# tor_publish_service_desc: "bridge"

--- a/playbooks/roles/tor-bridge/templates/torrc.j2
+++ b/playbooks/roles/tor-bridge/templates/torrc.j2
@@ -2,6 +2,7 @@ SocksPort 0
 ORPort {{ tor_orport }}
 ExtORPort auto
 BridgeRelay 1
+PublishServerDescriptor 0
 ExitPolicy reject *:*
 
 Nickname {{ tor_bridge_nickname.stdout }}

--- a/playbooks/roles/tor-bridge/templates/torrc.j2
+++ b/playbooks/roles/tor-bridge/templates/torrc.j2
@@ -2,7 +2,7 @@ SocksPort 0
 ORPort {{ tor_orport }}
 ExtORPort auto
 BridgeRelay 1
-PublishServerDescriptor 0
+PublishServerDescriptor {{ tor_publish_service_desc }}
 ExitPolicy reject *:*
 
 Nickname {{ tor_bridge_nickname.stdout }}


### PR DESCRIPTION
This PR obsoletes https://github.com/jlund/streisand/pull/647 by completing the remaining review feedback required for merge.

The original PR description said:
> In this case "private" means that the bridge is configured with the option PublishServerDescriptor 0. Without this option set, The Tor Project can learn about the bridge and may distribute its address to others.
https://www.whonix.org/wiki/Bridges#Additional_Information_and_Recommendations

User's that wish to publish their tor-bridge can uncomment the `tor_publish_service_desc: "bridge"` line from the torrc.j2 config template.

A follow-up task is to implement https://github.com/jlund/streisand/issues/655 and allow prompting for the value of this setting.

Thanks to @amsqube for the initial implementation in #647 :cake: :tada: :fireworks: 