### PR TITLE
resolvconf: support Debian's broken resolvconf

### DIFF
--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -5,8 +5,8 @@ Address = 10.192.122.2/32
 #
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
-PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a %i -m 0 -x
-PostDown = resolvconf -d %i
+PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a tun.%i -m 0 -x
+PostDown = resolvconf -d tun.%i
 PrivateKey = {{ wireguard_client_private_key }}
 
 [Peer]


### PR DESCRIPTION
This patch is untested, and won't really be easily testable until
EggieCode/wireguard-ppa#20 is merged and uploaded. However, without
testing, several observations struck me:

- resolvconf doesn't need real interface names. A bogus name will work
  just fine.
- Prefixing an arbitrary name with 'tun' moves it to the top-ish of the
  list.
- Debian's resolvconf ignores arguments after the first, so we can still
  continue to supply the openresolv flags for implementations that
  support it.

Thus, we give resolvconf tun.%i, and this should work good enough. There
are a few limitations, however:

- The DNS server is not _exclusive_, which means that if it doesn't
  reply in time, the resolver might choose to try other servers. This is
  a security feature limitation of Debian's resolvconf. Not our problem,
  perhaps?
- This doesn't handle anything with the convoluted --enable-updates/
  disable-updates logic, which may or may not be in use, in which case,
  who knows what to do.
- Building on that last point, I'm still uncertain exactly how Ubuntu's
  use of dnsmasq interacts with --enable-updates/disable-updates and
  resolvconf in general.

So, all and all this might be a bug-fix improvement over before, but
still not perfect. Incremental baby steps.

Signed-off-by: Jason A. Donenfeld <Jason@zx2c4.com>