### PR TITLE
Removes README claim RE: client IP logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ More Features
 * Every task has been thoroughly documented and given a detailed description. Streisand is simultaneously the most complete HOWTO in existence for the setup of all of the software it installs, and also the antidote for ever having to do any of this by hand again.
 * All software runs on ports that have been deliberately chosen to make simplistic port blocking unrealistic without causing massive collateral damage. OpenVPN, for example, does not run on its default port of 1194, but instead uses port 636, the standard port for LDAP/SSL connections that are beloved by companies worldwide.
   * *L2TP/IPsec is a notable exception to this rule because the ports cannot be changed without breaking client compatibility*
-* The IP addresses of connecting clients are never logged. There's nothing to find if a server gets seized or shut down.
 
 <a name="services-provided"></a>
 Services Provided


### PR DESCRIPTION
The README has a feature line describing the Streisand server's logging
configuration w.r.t. trying to minimize client IP collection. My
understanding of the original intent was that this was considered from
the perspective of one sysadmin running a Streisand instance for many
clients, whose IPs would be ideally not recorded. This has caused some
some confusion[0] for folks thinking it was about the sysadmin/operator
themselves.

Overall I think this conversation requires a deeper conversation RE:
threat models and we should probably stay out of the weeds by saying
less in the README :-)

[0]: https://arstechnica.com/gadgets/2017/05/how-to-build-your-own-vpn-if-youre-rightfully-wary-of-commercial-options/?comments=1&post=33391773