### PR TITLE
Revert "shadowsocks: listen on streisand_ipv4_address (#707)"

### DIFF
--- a/playbooks/roles/shadowsocks/templates/config.json.j2
+++ b/playbooks/roles/shadowsocks/templates/config.json.j2
@@ -1,5 +1,5 @@
 {
-    "server":"{{ streisand_ipv4_address }}",
+    "server":"{{ ansible_default_ipv4.address }}",
     "server_port":{{ shadowsocks_server_port }},
     "local_port":{{ shadowsocks_local_port }},
     "password":"{{ shadowsocks_password.stdout }}",


### PR DESCRIPTION
This reverts commit 282d5eac6b12d33c89a434d0042c2e2b646b61d8
from https://github.com/jlund/streisand/pull/707.

It causes issues on AWS from the I think the primary interface address
having an internal 10.x VPC IP that doesn't match the external IP.