### PR TITLE
Require `dmidecode` package presence for provider-detection.

### DIFF
--- a/playbooks/provider-detect.yml
+++ b/playbooks/provider-detect.yml
@@ -10,6 +10,10 @@
   become: true
 
   tasks:
+    - name: "Install dmidecode to use for BIOS version detection"
+      apt:
+        name: dmidecode
+
     - name: "Try to determine localhost Cloud provider name from BIOS version"
       # Looking into ways to detect EC2/GCE instances without relying on
       # connections to metadata IPs this solution[0] seemed the most


### PR DESCRIPTION
Some providers (e.g. Scaleway) do not include `dmidecode` in the base
Ubuntu 16.04 image so we must explicitly request it be installed before
trying to use it for provider detection.

Thanks to @dmitry-kulikov for reporting. Resolves https://github.com/jlund/streisand/issues/738