### PR TITLE
Adds support for mirroring localized versions of the Tor Browser Bundle

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -7,3 +7,5 @@ streisand_ci: no
 
 streisand_client_test: no
 streisand_noninteractive: no
+
+gpg_key_server_address: "x-hkp://pool.sks-keyservers.net"

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -53,6 +53,8 @@ streisand_languages:
   en:
     file_suffix: ""
     language_name: "English"
+    tor_locale: "en-US"
   fr:
     file_suffix: "-fr"
     language_name: "Français"
+    tor_locale: "fr"

--- a/playbooks/roles/download-and-verify/tasks/main.yml
+++ b/playbooks/roles/download-and-verify/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: "{{ project_signer }} signs the {{ project_name }} downloads. Import the correct GPG key."
-  command: gpg --keyserver x-hkp://pool.sks-keyservers.net --recv-keys {{ project_signing_key }}
+  command: gpg --keyserver {{ gpg_key_server_address }} --recv-keys {{ project_signing_key }}
   register: gpg_recv_keys_result
   until: gpg_recv_keys_result | success
   retries: 10
@@ -13,7 +13,7 @@
 - name: Make sure the retrieved fingerprint perfectly matches the expected fingerprint
   assert: { that: "project_expected_fingerprint in retrieved_fingerprint.stdout" }
 
-- name: Mirror the {{ project_name }} files and signatures
+- name: Download the {{ project_name }} files and signatures
   get_url:
     url: "{{ item }}"
     dest: "{{ project_download_location }}"

--- a/playbooks/roles/streisand-mirror/tasks/tor-common.yml
+++ b/playbooks/roles/streisand-mirror/tasks/tor-common.yml
@@ -1,0 +1,42 @@
+---
+
+- name: Make the directory where the Tor Project's mirrored files will be stored
+  file:
+    path: "{{ tor_mirror_location }}"
+    owner: www-data
+    group: www-data
+    mode: 0755
+    state: directory
+
+- name: Discover the latest stable version of the Tor Browser Bundle
+  # The Python code below can be cleaned up once the Tor Project has
+  # finished transitioning away from putting the OS suffix in the
+  # RecommendedTBBVersions file. This check should work with both
+  # formats though.
+  #
+  # https://trac.torproject.org/projects/tor/ticket/8940#comment:28
+  shell: curl -s 'https://www.torproject.org/projects/torbrowser/RecommendedTBBVersions' | python -c 'import json; import re; import sys; j = json.load(sys.stdin); print [re.sub(r"-.*$", "", tbb) for tbb in j if "a" not in tbb and "b" not in tbb][-1];'
+  args:
+    warn: no
+  register: tor_latest_recommended_check
+
+- name: Set the target Tor Browser Bundle version
+  set_fact:
+    tor_browser_bundle_version: "{{ tor_latest_recommended_check.stdout }}"
+
+- name: "Import GPG key ID {{ tor_browser_developers_key_id }} for verifying {{ tor_project_name }} downloads"
+  command: gpg --keyserver {{ gpg_key_server_address }} --recv-keys {{ tor_browser_developers_key_id }}
+  register: gpg_recv_keys_result
+  until: gpg_recv_keys_result | success
+  retries: 10
+  delay: 5
+
+- name: Register the GPG Key fingerprint output
+  command: gpg --fingerprint {{ tor_browser_developers_key_id }}
+  register: retrieved_fingerprint
+
+- name: Make sure the retrieved fingerprint perfectly matches the expected fingerprint
+  assert: { that: "tor_browser_developers_expected_fingerprint in retrieved_fingerprint.stdout" }
+
+- name: Include the mirror variables for Tor Browser Bundle
+  include_vars: tor-mirror.yml

--- a/playbooks/roles/streisand-mirror/tasks/tor-download.yml
+++ b/playbooks/roles/streisand-mirror/tasks/tor-download.yml
@@ -1,0 +1,12 @@
+---
+- name: Include the Tor download variables for locale ({{ locale }})
+  include_vars: tor-download.yml
+
+- name: Downloading {{ tor_project_name }} files and signatures for locale ({{ locale }})
+  get_url:
+    url: "{{ item }}"
+    dest: "{{ tor_mirror_location }}"
+    owner: www-data
+    group: www-data
+    mode: 0644
+  with_items: "{{ tor_download_urls }}"

--- a/playbooks/roles/streisand-mirror/tasks/tor-verify.yml
+++ b/playbooks/roles/streisand-mirror/tasks/tor-verify.yml
@@ -1,0 +1,9 @@
+---
+- name: Register GPG signature verification results
+  shell: for file in *.asc; do gpg --verify $file; done
+  args:
+    chdir: "{{ tor_mirror_location }}"
+  register: gpg_verification_results
+
+- name: Make sure the {{ tor_project_name }} files all passed GPG signature verfication
+  assert: { that: "'BAD signature' not in gpg_verification_results.stderr" }

--- a/playbooks/roles/streisand-mirror/tasks/tor.yml
+++ b/playbooks/roles/streisand-mirror/tasks/tor.yml
@@ -1,41 +1,17 @@
 ---
-- name: Include the Tor mirror variables
-  include_vars: tor.yml
-
-- name: Make the directory where the Tor Project's mirrored files will be stored
-  file:
-    path: "{{ tor_mirror_location }}"
-    owner: www-data
-    group: www-data
-    mode: 0755
-    state: directory
+- name: Include the Tor common variables
+  include_vars: tor-common.yml
 
 - block:
-    - name: Discover the latest stable version of the Tor Browser Bundle
-      # The Python code below can be cleaned up once the Tor Project has
-      # finished transitioning away from putting the OS suffix in the
-      # RecommendedTBBVersions file. This check should work with both
-      # formats though.
-      #
-      # https://trac.torproject.org/projects/tor/ticket/8940#comment:28
-      shell: curl -s 'https://www.torproject.org/projects/torbrowser/RecommendedTBBVersions' | python -c 'import json; import re; import sys; j = json.load(sys.stdin); print [re.sub(r"-.*$", "", tbb) for tbb in j if "a" not in tbb and "b" not in tbb][-1];'
-      args:
-        warn: no
-      register: tor_latest_recommended_check
+    - include: tor-common.yml
 
-    - name: Set the target Tor Browser Bundle version
-      set_fact:
-        tor_browser_bundle_version: "{{ tor_latest_recommended_check.stdout }}"
+    - include: tor-download.yml
+      with_items: "{{ streisand_languages.values() | map(attribute='tor_locale') | list }}"
+      when: locale in tor_available_locales
+      loop_control:
+        loop_var: locale
 
-    - include_role:
-        name: download-and-verify
-      vars:
-        project_name: "Tor Browser Bundle"
-        project_signer: "Tor Browser Developers"
-        project_signing_key: "{{ tor_browser_developers_key_id }}"
-        project_expected_fingerprint: "{{ tor_browser_developers_expected_fingerprint }}"
-        project_download_location: "{{ tor_mirror_location }}"
-        project_download_urls: "{{ tor_download_urls }}"
+    - include: tor-verify.yml
   rescue:
     - name: "{{ streisand_mirror_warning }}"
       pause:

--- a/playbooks/roles/streisand-mirror/templates/mirror-index-fr.md.j2
+++ b/playbooks/roles/streisand-mirror/templates/mirror-index-fr.md.j2
@@ -92,13 +92,13 @@ Les fichiers reflétés ci-dessous ont tous été cryptographiquement vérifiés
 
 **Linux**
 
-* [{{ tor_browser_bundle_linux32_filename }}]({{ tor_browser_bundle_linux32_href }}) ([sig]({{ tor_browser_bundle_linux32_sig_href }}))
-* [{{ tor_browser_bundle_linux64_filename }}]({{ tor_browser_bundle_linux64_href }}) ([sig]({{ tor_browser_bundle_linux64_sig_href }}))
+* [{{ tor_linux32_filename_template | regex_replace('locale', item.value.tor_locale) }}]({{ tor_linux32_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_linux32_sig_href | regex_replace('locale', item.value.tor_locale) }}))
+* [{{ tor_linux64_filename_template | regex_replace('locale', item.value.tor_locale) }}]({{ tor_linux64_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_linux64_sig_href | regex_replace('locale', item.value.tor_locale) }}))
 
 **OS X**
 
-* [{{ tor_browser_bundle_osx_filename }}]({{ tor_browser_bundle_osx_href }}) ([sig]({{ tor_browser_bundle_osx_sig_href }}))
+* [{{ tor_osx_filename_template | regex_replace('locale', item.value.tor_locale) }}]({{ tor_osx_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_osx_sig_href | regex_replace('locale', item.value.tor_locale) }}))
 
 **Windows**
 
-* [{{ tor_browser_bundle_windows_filename }}]({{ tor_browser_bundle_windows_href }}) ([sig]({{ tor_browser_bundle_windows_sig_href }}))
+* [{{ tor_windows_filename_template |  regex_replace('locale', item.value.tor_locale) }}]({{ tor_windows_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_windows_sig_href | regex_replace('locale', item.value.tor_locale) }}))

--- a/playbooks/roles/streisand-mirror/templates/mirror-index.md.j2
+++ b/playbooks/roles/streisand-mirror/templates/mirror-index.md.j2
@@ -92,13 +92,13 @@ The files mirrored below have all been cryptographically verified. Where possibl
 
 **Linux**
 
-* [{{ tor_browser_bundle_linux32_filename }}]({{ tor_browser_bundle_linux32_href }}) ([sig]({{ tor_browser_bundle_linux32_sig_href }}))
-* [{{ tor_browser_bundle_linux64_filename }}]({{ tor_browser_bundle_linux64_href }}) ([sig]({{ tor_browser_bundle_linux64_sig_href }}))
+* [{{ tor_linux32_filename_template | regex_replace('locale', item.value.tor_locale)  }}]({{ tor_linux32_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_linux32_sig_href | regex_replace('locale', item.value.tor_locale) }}))
+* [{{ tor_linux64_filename_template | regex_replace('locale', item.value.tor_locale)  }}]({{ tor_linux64_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_linux64_sig_href | regex_replace('locale', item.value.tor_locale) }}))
 
 **OS X**
 
-* [{{ tor_browser_bundle_osx_filename }}]({{ tor_browser_bundle_osx_href }}) ([sig]({{ tor_browser_bundle_osx_sig_href }}))
+* [{{ tor_osx_filename_template | regex_replace('locale', item.value.tor_locale) }}]({{ tor_osx_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_osx_sig_href | regex_replace('locale', item.value.tor_locale) }}))
 
 **Windows**
 
-* [{{ tor_browser_bundle_windows_filename }}]({{ tor_browser_bundle_windows_href }}) ([sig]({{ tor_browser_bundle_windows_sig_href }}))
+* [{{ tor_windows_filename_template | regex_replace('locale', item.value.tor_locale) }}]({{ tor_windows_href | regex_replace('locale', item.value.tor_locale) }}) ([sig]({{ tor_windows_sig_href | regex_replace('locale', item.value.tor_locale) }}))

--- a/playbooks/roles/streisand-mirror/vars/tor-common.yml
+++ b/playbooks/roles/streisand-mirror/vars/tor-common.yml
@@ -1,0 +1,31 @@
+---
+# Tor common variables
+# --------------------
+
+tor_project_name: "Tor Browser Bundle"
+
+tor_mirror_location: "{{ streisand_mirror_location }}/tor"
+tor_mirror_href_base: "/mirror/tor"
+
+tor_browser_developers_key_id: "0x4E2C6E8793298290"
+tor_browser_developers_expected_fingerprint: "Key fingerprint = EF6E 286D DA85 EA2A 4BA7  DE68 4E2C 6E87 9329 8290"
+
+tor_base_download_url: "https://dist.torproject.org/torbrowser"
+
+tor_available_locales:
+  - ar
+  - de
+  - en-US
+  - es-ES
+  - fa
+  - fr
+  - it
+  - ja
+  - ko
+  - nl
+  - pl
+  - pt-BR
+  - ru
+  - tr
+  - vi
+  - zh-CN

--- a/playbooks/roles/streisand-mirror/vars/tor-download.yml
+++ b/playbooks/roles/streisand-mirror/vars/tor-download.yml
@@ -1,42 +1,27 @@
 ---
-# Tor Download variables
+# Tor download variables
 # ----------------------
-tor_mirror_location: "{{ streisand_mirror_location }}/tor"
-tor_mirror_href_base: "/mirror/tor"
-
-tor_browser_developers_key_id: "0x4E2C6E8793298290"
-tor_browser_developers_expected_fingerprint: "Key fingerprint = EF6E 286D DA85 EA2A 4BA7  DE68 4E2C 6E87 9329 8290"
-
-tor_base_download_url: "https://dist.torproject.org/torbrowser"
 
 # Windows
-tor_browser_bundle_windows_filename: "torbrowser-install-{{ tor_browser_bundle_version }}_en-US.exe"
+tor_browser_bundle_windows_filename: "{{ tor_windows_filename_base }}_{{ locale }}.exe"
 tor_browser_bundle_windows_sig_filename: "{{ tor_browser_bundle_windows_filename }}.asc"
-tor_browser_bundle_windows_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_windows_filename }}"
-tor_browser_bundle_windows_sig_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_windows_sig_filename }}"
 tor_browser_bundle_windows_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_windows_filename }}"
 tor_browser_bundle_windows_sig_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_windows_sig_filename }}"
 
 # OS X
-tor_browser_bundle_osx_filename: "TorBrowser-{{ tor_browser_bundle_version }}-osx64_en-US.dmg"
+tor_browser_bundle_osx_filename: "{{ tor_osx_filename_base }}_{{ locale }}.dmg"
 tor_browser_bundle_osx_sig_filename: "{{ tor_browser_bundle_osx_filename }}.asc"
-tor_browser_bundle_osx_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_osx_filename }}"
-tor_browser_bundle_osx_sig_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_osx_sig_filename }}"
 tor_browser_bundle_osx_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_osx_filename }}"
 tor_browser_bundle_osx_sig_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_osx_sig_filename }}"
 
 # Linux
-tor_browser_bundle_linux32_filename: "tor-browser-linux32-{{ tor_browser_bundle_version }}_en-US.tar.xz"
+tor_browser_bundle_linux32_filename: "{{ tor_linux32_filename_base }}_{{ locale }}.tar.xz"
 tor_browser_bundle_linux32_sig_filename: "{{ tor_browser_bundle_linux32_filename }}.asc"
-tor_browser_bundle_linux32_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_linux32_filename }}"
-tor_browser_bundle_linux32_sig_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_linux32_sig_filename }}"
 tor_browser_bundle_linux32_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_linux32_filename }}"
 tor_browser_bundle_linux32_sig_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_linux32_sig_filename }}"
 
-tor_browser_bundle_linux64_filename: "tor-browser-linux64-{{ tor_browser_bundle_version }}_en-US.tar.xz"
+tor_browser_bundle_linux64_filename: "{{ tor_linux64_filename_base }}_{{ locale }}.tar.xz"
 tor_browser_bundle_linux64_sig_filename: "{{ tor_browser_bundle_linux64_filename }}.asc"
-tor_browser_bundle_linux64_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_linux64_filename }}"
-tor_browser_bundle_linux64_sig_href: "{{ tor_mirror_href_base }}/{{ tor_browser_bundle_linux64_sig_filename }}"
 tor_browser_bundle_linux64_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_linux64_filename }}"
 tor_browser_bundle_linux64_sig_url: "{{ tor_base_download_url }}/{{ tor_browser_bundle_version }}/{{ tor_browser_bundle_linux64_sig_filename }}"
 

--- a/playbooks/roles/streisand-mirror/vars/tor-mirror.yml
+++ b/playbooks/roles/streisand-mirror/vars/tor-mirror.yml
@@ -1,0 +1,27 @@
+---
+# Tor mirror variables
+# --------------------
+
+tor_windows_filename_base: "torbrowser-install-{{ tor_browser_bundle_version }}"
+tor_windows_filename_template: "{{ tor_windows_filename_base }}_locale.exe"
+tor_windows_sig_filename_template: "{{ tor_windows_filename_template }}.asc"
+tor_windows_href: "{{ tor_mirror_href_base }}/{{ tor_windows_filename_template }}"
+tor_windows_sig_href: "{{ tor_mirror_href_base }}/{{ tor_windows_sig_filename_template }}"
+
+tor_osx_filename_base: "TorBrowser-{{ tor_browser_bundle_version }}-osx64"
+tor_osx_filename_template: "{{ tor_osx_filename_base }}_locale.dmg"
+tor_osx_sig_filename_template: "{{ tor_osx_filename_template }}.asc"
+tor_osx_href: "{{ tor_mirror_href_base }}/{{ tor_osx_filename_template }}"
+tor_osx_sig_href: "{{ tor_mirror_href_base }}/{{ tor_osx_sig_filename_template }}"
+
+tor_linux32_filename_base: "tor-browser-linux32-{{ tor_browser_bundle_version }}"
+tor_linux32_filename_template: "{{ tor_linux32_filename_base }}_locale.tar.xz"
+tor_linux32_sig_filename_template: "{{ tor_linux32_filename_template }}.asc"
+tor_linux32_href: "{{ tor_mirror_href_base }}/{{ tor_linux32_filename_template }}"
+tor_linux32_sig_href: "{{ tor_mirror_href_base }}/{{ tor_linux32_sig_filename_template }}"
+
+tor_linux64_filename_base: "tor-browser-linux64-{{ tor_browser_bundle_version }}"
+tor_linux64_filename_template: "{{ tor_linux64_filename_base }}_locale.tar.xz"
+tor_linux64_sig_filename_template: "{{ tor_linux64_filename_template }}.asc"
+tor_linux64_href: "{{ tor_mirror_href_base }}/{{ tor_linux64_filename_template }}"
+tor_linux64_sig_href: "{{ tor_mirror_href_base }}/{{ tor_linux64_sig_filename_template }}"

--- a/tests/group_vars/all/all
+++ b/tests/group_vars/all/all
@@ -27,3 +27,5 @@ libreswan_compilation_dependencies_trusty:
   - libunbound-dev
   - make
   - pkg-config
+
+gpg_key_server_address: "x-hkp://pool.sks-keyservers.net"


### PR DESCRIPTION
In order to support mirroring localized versions of Tor, steps taken from the `download-and-verify` task were unrolled and modified into three distinct steps specifically for Tor:

1. `tor-common`&nbsp;&nbsp;&nbsp;&nbsp;- Determining the recommended TBB version and registering the GPG keys
2. `tor-download`&nbsp;- Downloads TBB for the locales defined in `streisand_languages`
3. `tor-verify`&nbsp;&nbsp;&nbsp;&nbsp;- Integrity verification 

Furthermore, the download task is gated only to available locales that TBB supports defined as `tor-available-locales`. 
