### PR TITLE
Remove lxd and snapd from default installation

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -17,6 +17,14 @@
     name: "{{ item }}"
   with_items: "{{ streisand_common_packages }}"
 
+- name: Purge unneeded services
+  apt:
+    name: "{{ item }}"
+    state: "absent"
+    purge: yes
+    autoremove: yes
+  with_items: "{{ streisand_unneeded_packages }}"
+
 - name: Perform a full system upgrade
   apt:
     upgrade: "safe"

--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -34,6 +34,11 @@ streisand_common_packages:
   # (yet typeable!) passphrases
   - wamerican-huge
 
+# Services that are running by default but not needed by Streisand
+streisand_unneeded_packages:
+  - lxd
+  - snapd
+
 streisand_gateway_location: "/var/www/streisand"
 
 streisand_local_directory: "generated-docs"


### PR DESCRIPTION
These services are part of default Ubuntu installation. Since Streisand
doesn't use any of those, it's safe to remove them completely.

Closes #703 