### PR TITLE
Update the OpenVPN mirror GPG key and fingerprint

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
   - sudo apt-get install python-pip python-dev ca-certificates shellcheck -qq
 
 install:
-  - pip install ansible==2.3.0.0
+  - pip install ansible==2.3.1.0
   - pip install urllib3
   - ansible --version
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ dist: trusty
 language: python
 python: "2.7"
 
+group: edge
+
 # Use isolated GCE instance
 sudo: required
 

--- a/playbooks/roles/streisand-mirror/vars/openvpn.yml
+++ b/playbooks/roles/streisand-mirror/vars/openvpn.yml
@@ -4,8 +4,8 @@
 openvpn_mirror_location: "{{ streisand_mirror_location }}/openvpn"
 openvpn_mirror_href_base: "/mirror/openvpn"
 
-openvpn_samuli_seppanen_key_id: "0x29584D9F40864578"
-openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = 6D04 F8F1 B017 3111 F499  795E 2958 4D9F 4086 4578"
+openvpn_samuli_seppanen_key_id: "0x12F5F7B42F2B01E7"
+openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = F554 A368 7412 CFFE BDEF  E0A3 12F5 F7B4 2F2B 01E7"
 
 openvpn_base_download_url: "https://build.openvpn.net/downloads/releases/latest"
 

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -10,7 +10,7 @@ command -v ansible > /dev/null 2>&1 || {
   exit 1
 }
 
-required_ansible_version="2.3.0.0"
+required_ansible_version="2.3.1.0"
 
 if [[ "$(ansible --version | grep -oe '2\(.[0-9]\)*')" < $required_ansible_version ]]
 then


### PR DESCRIPTION
It would appear that the OpenVPN team has a new GPG key used to sign releases for v2.4.3+.
This PR addresses mirroring errors failures due to the new key.