### PR TITLE
Update the OpenVPN mirror GPG key and fingerprint

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/openvpn.yml
+++ b/playbooks/roles/streisand-mirror/vars/openvpn.yml
@@ -31,9 +31,9 @@ openvpn_download_urls:
 
 
 # OS X
-tunnelblick_version: "3.7.1a"
-tunnelblick_build: "4812"
+tunnelblick_version: "3.7.1b"
+tunnelblick_build: "4813"
 tunnelblick_filename: "Tunnelblick_{{ tunnelblick_version }}_build_{{ tunnelblick_build }}.dmg"
 tunnelblick_href: "{{ openvpn_mirror_href_base }}/{{ tunnelblick_filename }}"
 tunnelblick_url: "https://tunnelblick.net/release/{{ tunnelblick_filename }}"
-tunnelblick_checksum: "sha256:66f99c50a8cad2985ecc224e378dbd79bb01c3d6b66ae7b16f69b780ee76b6c9"
+tunnelblick_checksum: "sha256:60419937cb72ebe59d40e13a80c4e5c31231a7c5fb8f3affbcbc95b9b41295b1"

--- a/playbooks/roles/streisand-mirror/vars/openvpn.yml
+++ b/playbooks/roles/streisand-mirror/vars/openvpn.yml
@@ -4,8 +4,8 @@
 openvpn_mirror_location: "{{ streisand_mirror_location }}/openvpn"
 openvpn_mirror_href_base: "/mirror/openvpn"
 
-openvpn_samuli_seppanen_key_id: "0x29584D9F40864578"
-openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = 6D04 F8F1 B017 3111 F499  795E 2958 4D9F 4086 4578"
+openvpn_samuli_seppanen_key_id: "0x12F5F7B42F2B01E7"
+openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = F554 A368 7412 CFFE BDEF  E0A3 12F5 F7B4 2F2B 01E7"
 
 openvpn_base_download_url: "https://build.openvpn.net/downloads/releases/latest"
 


### PR DESCRIPTION
It would appear that the OpenVPN team has a new GPG key used to sign releases for v2.4.3+.
This PR addresses mirroring errors failures due to the new key.

Resolves #752