### PR TITLE
Fix CI by working around Ansible `apt_repository` bug.

### DIFF
--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -25,6 +25,12 @@
     - name: Install LXC ppa
       command: add-apt-repository ppa:ubuntu-lxc/lxd-stable
 
+    - name: Ensure consistent & clean apt state
+      shell: "{{ item }}"
+      with_items:
+        - "apt-get clean"
+        - "apt-get update"
+
     # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
     - name: Install the Libreswan dependencies that are required for compilation
       apt:
@@ -86,7 +92,6 @@
       apt:
         name: lxd
         state: latest
-        update_cache: yes
 
     - name: lxd new group
       shell: newgrp lxd

--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -18,15 +18,14 @@
         url: "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD5495F657635B973"
         state: present
 
-    - name: Install lxc ppa
-      apt_repository:
-        repo: "{{ item }}"
-        state: present
-      with_items:
-        - "deb http://ppa.launchpad.net/ubuntu-lxc/lxd-stable/ubuntu {{ansible_distribution_release}} main"
-        - "deb-src http://ppa.launchpad.net/ubuntu-lxc/lxd-stable/ubuntu {{ansible_distribution_release}} main"
+    # NOTE(@cpu): We use the `command` module with the `add-apt-repository`
+    # command here because the `apt_repository` Ansible module at the time of
+    # writing will error on the ubuntu-lxc repo in some instances if a mirror is
+    # missing 32bit binary builds even though CI uses a 64bit architecture.
+    - name: Install LXC ppa
+      command: add-apt-repository ppa:ubuntu-lxc/lxd-stable
 
-      # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
+    # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
     - name: Install the Libreswan dependencies that are required for compilation
       apt:
         name: "{{ item }}"


### PR DESCRIPTION
The Ansible `apt_repository` module at the time of writing is choking on
the ubuntu-lxc ppa repository because one of the mirrors is missing
binary-i386 builds. We don't actually **use** i386 builds because Travis
is x86_64 by default. We can work around this error by using the
`add-apt-repository` via the Ansible `command` module instead of doing
things the "right" way. This can be reverted when the upstream
`add-apt-repository` module is fixed.

Resolves https://github.com/jlund/streisand/issues/758