### PR TITLE
CI enhancements/shell script cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: trusty
 language: python
 python: "2.7"
 
-# Use isolated GCE instance
+# Use isolated build instance
 sudo: required
 
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,4 +29,4 @@ script:
   # * shellcheck tests for common shell script errors
   # * ./tests/test.sh syntax will check for Ansible syntax errors
   # * ./tests/test.sh ci will install dev dependencies and run the ci playbooks
-  - shellcheck ./streisand && shellcheck ./tests/tests.sh && ./tests/tests.sh syntax && ./tests/test.sh ci
+  - shellcheck -x ./streisand && shellcheck -x ./tests/tests.sh && ./tests/tests.sh syntax && ./tests/tests.sh ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,13 @@ install:
   - ansible --version
 
 script:
-  # Run shellcheck lint on streisand script
-  - shellcheck ./streisand
-  # Run syntax checks on playbooks and roles
-  - ./tests/tests.sh syntax
-  # Install additional packages, configure lxc, start streisand container
-  # Run entire playbook against lxc container
-  - ./tests/tests.sh ci
+  # Travis will run all `script` tasks even if one fails. In order to have the
+  # first failure terminate the build we list each script step with the shell
+  # `&&` operator as one script task.
+  #
+  # https://docs.travis-ci.com/user/customizing-the-build/#Customizing-the-Build-Step
+  #
+  # * shellcheck tests for common shell script errors
+  # * ./tests/test.sh syntax will check for Ansible syntax errors
+  # * ./tests/test.sh ci will install dev dependencies and run the ci playbooks
+  - shellcheck ./streisand && shellcheck ./tests/tests.sh && ./tests/tests.sh syntax && ./tests/test.sh ci

--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -10,7 +10,7 @@ The `test.sh` wrapper script
 --------------------------------
 
 The `test/test.sh` wrapper script is invoked to perform tests and supports
-a argument for specifying what actions should be taken. The following are
+an argument for specifying what actions should be taken. The following are
 supported arguments:
 
 * **"setup"** prepares the local environment for running a Streisand
@@ -24,7 +24,7 @@ supported arguments:
 
 * **"ci"** combines "setup" and "run".
 
-* **"ful""** performs the same as "ci" but additionally adds verbose output to
+* **"full""** performs the same as "ci" but additionally adds verbose output to
     the Ansible run. This is very verbose but can be useful for diagnosing
     tricky broken builds.
 

--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -1,3 +1,53 @@
+CI Testing
+==========================
+
+Streisand has a `.travis.yml` file that powers [continuous integration
+tests](https://travis-ci.org/jlund/streisand). It works by installing required
+test tools (e.g. shellcheck) and an Ansible environment on a Ubuntu Trusty
+(14.04) machine.
+
+The `test.sh` wrapper script
+--------------------------------
+
+The `test/test.sh` wrapper script is invoked to perform tests and supports
+a argument for specifying what actions should be taken. The following are
+supported arguments:
+
+* **"setup"** prepares the local environment for running a Streisand
+    [LXC](https://linuxcontainers.org/lxc/introduction/) instance. The instance
+    is managed via [LXD](https://linuxcontainers.org/lxd/).
+
+* **"syntax"** checks the Streisand playbooks for Ansible syntax errors.
+
+* **"run"** runs the CI tests. It assumes the local environment is already
+    prepared from a previous "setup" run.
+
+* **"ci"** combines "setup" and "run".
+
+* **"ful""** performs the same as "ci" but additionally adds verbose output to
+    the Ansible run. This is very verbose but can be useful for diagnosing
+    tricky broken builds.
+
+* By **default** the wrapper will run "syntax".
+
+Working around things that won't work in Travis
+-----------------------------------------------
+
+Some playbooks/tasks can't be run in CI because of limitations imposed by the
+containerization or Travis. One example of this is installing a Tor relay. To
+work around this playbooks/tasks that break in CI can be gated on the
+`streisand_ci` variable, which is `true` only for CI runs. Where possible it's
+best to minimize the use of this variable for conditional execution because we
+want as much code to be tested as possible!
+
+Kernel Modules
+---------------------
+
+By design LXC containers share the Linux kernel they use with the host machine.
+This means playbooks/services that require a kernel module (e.g. Libreswan) must
+build the kernel module on the host machine.
+
+
 Local Testing
 ==========================
 

--- a/documentation/testing.md
+++ b/documentation/testing.md
@@ -24,7 +24,7 @@ supported arguments:
 
 * **"ci"** combines "setup" and "run".
 
-* **"full""** performs the same as "ci" but additionally adds verbose output to
+* **"full"** performs the same as "ci" but additionally adds verbose output to
     the Ansible run. This is very verbose but can be useful for diagnosing
     tricky broken builds.
 

--- a/streisand
+++ b/streisand
@@ -10,25 +10,8 @@ echo -e "\n\033[38;5;255m\033[48;5;234m\033[1m  S T R E I S A N D  \033[0m\n"
 # workarounds packaged as Python monkey patches
 export PYTHONPATH="$SCRIPT_DIR/monkey:$PYTHONPATH"
 
-# check_ansible checks that Ansible is installed on the local system
-# and that it is a supported version.
-function check_ansible() {
-  local REQUIRED_ANSIBLE_VERSION="2.3.0"
-
-  if ! command -v ansible > /dev/null 2>&1; then
-    echo "
-Streisand requires Ansible and it is not installed.
-Please see the README Installation section on Prerequisites"
-    exit 1
-  fi
-
-  if [[ $(ansible --version | grep -oe '2\(.[0-9]\)*') < $REQUIRED_ANSIBLE_VERSION ]]; then
-      echo "
-Streisand requires Ansible version $REQUIRED_ANSIBLE_VERSION or higher.
-This system has Ansible $(ansible --version)."
-      exit 1
-  fi
-}
+# Include the check_ansible function from ansible_check.sh
+source util/ansible_check.sh
 
 # check_python checks whether the 'python' interpreter is Python 2 or Python 3.
 # If it is Python 2 then the inventory file is updated to set the

--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -25,6 +25,12 @@
     - name: Install LXC ppa
       command: add-apt-repository ppa:ubuntu-lxc/lxd-stable
 
+    - name: Ensure consistent & clean apt state
+      shell: "{{ item }}"
+      with_items:
+        - "apt-get clean"
+        - "apt-get update"
+
     # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
     - name: Install the Libreswan dependencies that are required for compilation
       apt:
@@ -86,7 +92,6 @@
       apt:
         name: lxd
         state: latest
-        update_cache: yes
 
     - name: lxd new group
       shell: newgrp lxd

--- a/tests/development-setup.yml
+++ b/tests/development-setup.yml
@@ -18,15 +18,14 @@
         url: "http://keyserver.ubuntu.com:11371/pks/lookup?op=get&search=0xD5495F657635B973"
         state: present
 
-    - name: Install lxc ppa
-      apt_repository:
-        repo: "{{ item }}"
-        state: present
-      with_items:
-        - "deb http://ppa.launchpad.net/ubuntu-lxc/lxd-stable/ubuntu {{ansible_distribution_release}} main"
-        - "deb-src http://ppa.launchpad.net/ubuntu-lxc/lxd-stable/ubuntu {{ansible_distribution_release}} main"
+    # NOTE(@cpu): We use the `command` module with the `add-apt-repository`
+    # command here because the `apt_repository` Ansible module at the time of
+    # writing will error on the ubuntu-lxc repo in some instances if a mirror is
+    # missing 32bit binary builds even though CI uses a 64bit architecture.
+    - name: Install LXC ppa
+      command: add-apt-repository ppa:ubuntu-lxc/lxd-stable
 
-      # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
+    # Since LXC loads kernal modules from the host, we need to ensure libreswan is compiled and installed
     - name: Install the Libreswan dependencies that are required for compilation
       apt:
         name: "{{ item }}"

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -32,7 +32,7 @@ function dev_setup {
 }
 
 function run_tests {
-  run_playbook "$DIR/run.yml" -e streisand_ci=false "$1"
+  run_playbook "$DIR/run.yml" -e streisand_ci=true "$1"
 }
 
 function ci_tests {

--- a/tests/tests.sh
+++ b/tests/tests.sh
@@ -1,27 +1,74 @@
 #!/usr/bin/env bash
-# Streisand syntax check.
+# Streisand CI test script.
+# Usage:
+#  ./tests.sh [setup|syntax|run|ci|full]
+
+# Set errexit option to exit immediately on any non-zero status return
 set -e
 
+echo -e "\n\033[38;5;255m\033[48;5;234m\033[1m  S T R E I S A N D  \033[0m\n"
+
+# Compute an absolute path to the test ansible.cfg file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 export ANSIBLE_CONFIG=$DIR/ansible.cfg
 
-command -v ansible > /dev/null 2>&1 || {
-  echo "Ansible is not installed."
-  exit 1
+# Include the check_ansible function from ansible_check.sh
+source util/ansible_check.sh
+
+function run_playbook {
+  PLAYBOOK="$1"
+  EXTRA_FLAGS=(${@:2})
+  ansible-playbook -i "$DIR/inventory" "$PLAYBOOK" "${EXTRA_FLAGS[@]}"
 }
 
-required_ansible_version="2.3.0.0"
+# syntax_check runs `ansible-playbook` with `--syntax-check` to vet Ansible
+# playbooks for syntax errors
+function syntax_check {
+  run_playbook "$DIR/syntax-check.yml" --syntax-check -vv
+}
 
-if [[ "$(ansible --version | grep -oe '2\(.[0-9]\)*')" < $required_ansible_version ]]
-then
-    echo "Ansible $required_ansible_version or higher is required."
-    exit 1
-fi
+function dev_setup {
+  run_playbook "$DIR/development-setup.yml"
+}
 
-if [ -z "$*" ]; then ansible-playbook -i $DIR/inventory $DIR/syntax-check.yml --syntax-check -vv ; fi
+function run_tests {
+  run_playbook "$DIR/run.yml" -e streisand_ci=false "$1"
+}
 
-if [[ $1 = "ci" ]]; then  ansible-playbook -i $DIR/inventory $DIR/development-setup.yml && ansible-playbook -i $DIR/inventory $DIR/run.yml -e streisand_ci=true; fi
-if [[ $1 = "full" ]]; then  ansible-playbook -i $DIR/inventory $DIR/development-setup.yml -vv && ansible-playbook -i $DIR/inventory $DIR/run.yml -vv -e streisand_ci=false; fi
-if [[ $1 = "run" ]]; then  ansible-playbook -i $DIR/inventory $DIR/run.yml -e streisand_ci=false -vv; fi
-if [[ $1 = "setup" ]]; then  ansible-playbook -i $DIR/inventory $DIR/development-setup.yml -vv; fi
-if [[ $1 = "syntax" ]]; then ansible-playbook -i $DIR/inventory $DIR/syntax-check.yml --syntax-check -vv ; fi
+function ci_tests {
+  dev_setup && run_tests
+}
+
+function ci_tests_verbose {
+  dev_setup && run_tests -vv
+}
+
+# Make sure the system is ready for the Streisand playbooks
+check_ansible
+
+case $1 in
+  # Setup only prepares the local environment for running a Streisand LXC
+  "setup")
+    dev_setup
+    ;;
+  # Syntax only checks for Ansible syntax errors
+  "syntax")
+    syntax_check
+    ;;
+  # Run will run CI tests assuming the local environment is already prepared
+  "run")
+    run_tests
+    ;;
+  # CI will setup the local environment and then run tests
+  "ci")
+    ci_tests
+    ;;
+  # Full will do the same as "ci" but with verbose output
+  "full")
+    ci_tests_verbose
+    ;;
+  # By default, just run a syntax_check
+  *)
+    syntax_check
+    ;;
+esac

--- a/util/ansible_check.sh
+++ b/util/ansible_check.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Set errexit option to exit immediately on any non-zero status return
+set -e
+
+# check_ansible checks that Ansible is installed on the local system
+# and that it is a supported version.
+function check_ansible() {
+  local REQUIRED_ANSIBLE_VERSION="2.3.0"
+
+  if ! command -v ansible > /dev/null 2>&1; then
+    echo "
+Streisand requires Ansible and it is not installed.
+Please see the README Installation section on Prerequisites"
+    exit 1
+  fi
+
+  if [[ $(ansible --version | grep -oe '2\(.[0-9]\)*') < $REQUIRED_ANSIBLE_VERSION ]]; then
+      echo "
+Streisand requires Ansible version $REQUIRED_ANSIBLE_VERSION or higher.
+This system has Ansible $(ansible --version)."
+      exit 1
+  fi
+}


### PR DESCRIPTION
## Ensure early build exit for failed CI scripts

Per Travis docs the way to have the build exit if one script fails is
to only specify one script and rely on shell operators to short circuit
on non-zero exit. Kind of ugly... but ok Travis............ if you say
so..........................

Resolves https://github.com/jlund/streisand/issues/725

## Refactor/Cleanup test/test.sh

This PR updates `tests/tests.sh` to have less duplication & to pass
a shellcheck invocation. The commonality between it and the base
`streisand` script was extracted to `util/ansible_check.sh` and included
in both places. To make shellcheck follow the includes we add a `-x` to
the `.travis.yml` invocation of shellcheck. A handful of if statements were
replaced by a case statement. Common ansible-playbook invocation
was refactored to a function.

## Document CI

This PR adds some high level documentation about CI to 
`documentation/testing.md` to hopefully make the testing more 
accessible to external contributors.