### PR TITLE
Enforce ansible_distribution_version is exactly 16.04

### DIFF
--- a/playbooks/roles/common/tasks/main.yml
+++ b/playbooks/roles/common/tasks/main.yml
@@ -2,7 +2,7 @@
 - name: Warn users if the server's Linux distribution is not Ubuntu 16.04
   pause:
     prompt: "Ubuntu 16.04 is the only officially supported distribution; the setup will probably fail. Press Enter if you still want to continue."
-  when: ansible_distribution != "Ubuntu" or ansible_distribution_major_version != "16"
+  when: ansible_distribution != "Ubuntu" or ansible_distribution_version != "16.04"
 
 # Set default variables
 - include: set-default-variables.yml


### PR DESCRIPTION
Previous to this commit the `playbooks/roles/common/tasks/main.yml`
block for enforcing that the machine is Ubuntu 16.04 was only checking
the `ansible_distribution` and the `ansible_distribution_major_version`,
meaning that Ubuntu 16.10 was treated the same as Ubuntu 16.04.

This commit reworks the check to enforce that
`ansible_distribution_version` is exactly 16.04.

Resolves https://github.com/jlund/streisand/issues/398 
Thanks to @damongant for the report