### PR TITLE
Update unattended-upgrades config to avoid conffile prompts.

### DIFF
--- a/playbooks/roles/common/files/50unattended-upgrades
+++ b/playbooks/roles/common/files/50unattended-upgrades
@@ -30,3 +30,10 @@ Unattended-Upgrade::Automatic-Reboot "true";
 // time instead of immediately
 //  Default: "now"
 Unattended-Upgrade::Automatic-Reboot-Time "00:00";
+
+// Avoid conffile dpkg prompt by *always* leaving the modified configuration in
+// place and putting the new package configuration in a .dpkg-dist file
+Dpkg::Options {
+   "--force-confdef";
+   "--force-confold";
+};


### PR DESCRIPTION
This PR updates the `50unattended-upgrades` configuration file that Streisand places in `/etc/apt/apt.conf.d` to add additional options for how to handle dpkg conffile conflicts.

If a package (e.g. `tor`) has a security update and a change to a config file (e.g. `/etc/tor/torrc`), and Streisand has modified that config file, then the security update will stall at a dpkg conffile prompt asking if the user wants to keep the modified Streisand config file or the new package one. This obviously isn't very good for headless servers. Instead, we want unattended-upgrades to leave the Streisand configuration in place 100% of the time and have the new config file placed next to it with a `.dpkg-dist` suffix.

To do so the `--force-confdef` and `--force-confold` dpkg options are used. More about these options and the dpkg conffile process can be found here:
https://raphaelhertzog.com/2010/09/21/debian-conffile-configuration-file-managed-by-dpkg/