### PR TITLE
Fix simple-obfs git clone local modifications conflict.

### DIFF
--- a/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
+++ b/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
@@ -3,6 +3,10 @@
     repo: "https://github.com/shadowsocks/simple-obfs"
     dest: "{{ simple_obfs_compilation_directory }}"
     version: "v{{simple_obfs_version}}"
+    # NOTE(@cpu): this force can be removed once a release >0.0.3 of simple-obfs
+    # is cut. There is a cached git copy of aclocal.m4 that causes untracked
+    # changes in 0.0.3 fixed with 8c22d on simple-obfs master.
+    force: yes
 
 - name: Update the simple-obfs source code submodules
   command: git submodule update --init --recursive

--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -31,7 +31,7 @@ shadowsocks_password_file: "{{ shadowsocks_location }}/shadowsocks-password.txt"
 
 # simple-obfs vars
 simple_obfs_version: "0.0.3"
-simple_obfs_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ simple_obfs_version }}"
+simple_obfs_compilation_directory: "/usr/local/src/shadowsocks-simple-obfs-{{ simple_obfs_version }}"
 simple_obfs_configure_flags: "--disable-documentation"
 
 # Add -v for verbose mode to help with debugging


### PR DESCRIPTION
With Shadowsocks simple-obfs v0.0.3 multiple invocations of the Shadowsocks playbook will error with the following:

    "changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no)."

Looking in the `simple_obfs_compilation_directory` we see that `aclocal.m4` has local modifications:

```
/usr/local/src/shadowsocks-libev-0.0.3# git status
HEAD detached at v0.0.3
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   aclocal.m4
```

While `aclocal.m4` [is present in the simple-obfs `.gitignore`](https://github.com/shadowsocks/simple-obfs/blob/ace8bd27a7a68fceb884937d938619dd7dfe5420/.gitignore#L3), it was checked into the repository beforehand causing this error after autoconf mutates it from a build.

This has been [fixed on the upstream simple-obfs master branch with commit 8c22d275b29fc85e3db036c135f5d61f67585f20](https://github.com/shadowsocks/simple-obfs/commit/8c22d275b29fc85e3db036c135f5d61f67585f20), but until there is a new release tagged we can work around it by adding "force:yes" to the git clone task and overwriting the repo even though there are changes.

In addition to adding the "force" directive this commit also updates the `simple_obfs_compilation_directory`. Previously it was using the same directory name as shadowsocks-libev, causing confusion.

Resolves #788 