### PR TITLE
Wait for the tor fingerprint file, move paths to vars.

### DIFF
--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -72,23 +72,27 @@
 
 - name: Wait until obfs4proxy information has shown up in its state file
   wait_for:
-    path: /var/lib/tor/pt_state/obfs4_state.json
+    path: "{{ tor_obfs_state_directory }}/obfs4_state.json"
     search_regex: "node-id"
 
 - name: Wait until the hidden service is online
   wait_for:
     path: "{{ tor_hidden_service_directory }}/hostname"
 
+- name: Wait until the server fingerprint file is generated
+  wait_for:
+    path: "{{ tor_state_directory }}/fingerprint"
+
 - name: Register the Tor Hidden Service hostname
   command: cat {{ tor_hidden_service_directory }}/hostname
   register: tor_hidden_service_hostname
 
 - name: Discover the server fingerprint
-  command: awk '{ print $2 }' /var/lib/tor/fingerprint
+  command: "awk '{ print $2 }' {{ tor_state_directory }}/fingerprint"
   register: tor_fingerprint
 
 - name: Discover the obfs4 certificate details
-  shell: cat /var/lib/tor/pt_state/obfs4_bridgeline.txt | grep 'Bridge obfs4' | sed -e 's/^.*cert=\(.*\) .*$/\1/'
+  shell: cat "{{ tor_obfs_state_directory }}/obfs4_bridgeline.txt" | grep 'Bridge obfs4' | sed -e 's/^.*cert=\(.*\) .*$/\1/'
   register: tor_obfs4_certificate
 
 - name: Create the Tor Gateway directory

--- a/playbooks/roles/tor-bridge/vars/main.yml
+++ b/playbooks/roles/tor-bridge/vars/main.yml
@@ -5,8 +5,12 @@ tor_standard_connection_details: "{{ streisand_ipv4_address }}:{{ tor_orport }}"
 
 tor_obfs4_bridge_line: "obfs4 {{ streisand_ipv4_address }}:{{ tor_obfs4_port }} {{ tor_fingerprint.stdout }} cert={{ tor_obfs4_certificate.stdout }} iat-mode=0"
 
-tor_hidden_service_directory: "/var/lib/tor/hidden_service/"
+tor_state_directory: "/var/lib/tor"
+
+tor_hidden_service_directory: "{{ tor_state_directory }}/hidden_service/"
 tor_hidden_service_url: "http://{{ tor_hidden_service_hostname.stdout }}"
+
+tor_obfs_state_directory: "{{ tor_state_directory }}/pt_state"
 
 tor_gateway_location: "{{ streisand_gateway_location }}/tor"
 


### PR DESCRIPTION
This PR adds a `wait_for` task for the `/var/lib/tor/fingerprint` file that we depend on existing later in the tor-bridge role. 

Additionally this PR moves some of the hardcoded task paths into vars and adds some quoting for safety.

Resolves #780.