### PR TITLE
Remove extra blank line to fix yamllint err.

### DIFF
--- a/playbooks/roles/shadowsocks/tasks/main.yml
+++ b/playbooks/roles/shadowsocks/tasks/main.yml
@@ -138,4 +138,3 @@
 
 # Mirror the Shadowsocks clients
 - include: mirror.yml
-


### PR DESCRIPTION
The order of https://github.com/jlund/streisand/pull/794 and https://github.com/jlund/streisand/pull/795 getting merged snuck a yamllint error into master that now breaks the build.

This PR fixes the error and the travis build. Sorry about that!