### PR TITLE
Add Streisand mirror to README.

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -1,7 +1,7 @@
 ![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
 
 - - -
-[English](README.md), [Français](README-fr.md)
+[English](README.md), [Français](README-fr.md) | [Mirror](https://area51.threeletter.agency)
 - - -
 
 Streisand

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect") - - - [English](README.md), [Français](README-fr.md), | [Mirror](https://area51.threeletter.agency) - - - [![Build Status](https://travis-ci.org/jlund/streisand.svg?branch=master)](https://travis-ci.org/jlund/streisand) 
+![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
+
+- - -
+[English](README.md), [Français](README-fr.md) | [Mirror](https://area51.threeletter.agency)
+- - -
+
+[![Build Status](https://travis-ci.org/jlund/streisand.svg?branch=master)](https://travis-ci.org/jlund/streisand)
+
 Streisand
 =========
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,4 @@
-![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
-
-- - -
-[English](README.md), [Français](README-fr.md), | [Mirror](https://area51.threeletter.agency)
-- - -
-
-[![Build Status](https://travis-ci.org/jlund/streisand.svg?branch=master)](https://travis-ci.org/jlund/streisand)
-
-
+![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect") - - - [English](README.md), [Français](README-fr.md), | [Mirror](https://area51.threeletter.agency) - - - [![Build Status](https://travis-ci.org/jlund/streisand.svg?branch=master)](https://travis-ci.org/jlund/streisand) 
 Streisand
 =========
 
@@ -163,7 +155,7 @@ Complete all of these tasks on your local home machine.
 
        git clone https://github.com/jlund/streisand.git && cd streisand
 
-   Or clone from the external mirror if Github is blocked.
+   Or clone from the external mirror if GitHub is blocked.
 
        git clone https://area51.threeletter.agency/mirrors/streisand.git && cd streisand
 2. Execute the Streisand script.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 ![Streisand Logo](https://raw.githubusercontent.com/jlund/streisand/master/logo.jpg "Automate the effect")
 
 - - -
-[English](README.md), [Français](README-fr.md)
+[English](README.md), [Français](README-fr.md), | [Mirror](https://area51.threeletter.agency)
 - - -
 
 [![Build Status](https://travis-ci.org/jlund/streisand.svg?branch=master)](https://travis-ci.org/jlund/streisand)
+
 
 Streisand
 =========
@@ -161,6 +162,10 @@ Complete all of these tasks on your local home machine.
 1. Clone the Streisand repository and enter the directory.
 
        git clone https://github.com/jlund/streisand.git && cd streisand
+
+   Or clone from the external mirror if Github is blocked.
+
+       git clone https://area51.threeletter.agency/mirrors/streisand.git && cd streisand
 2. Execute the Streisand script.
 
        ./streisand


### PR DESCRIPTION
In the effort to make Streisand available when Github is not there is
a Gitlab mirror of Streisand available at
https://area51.threeletter.agency/mirrors/streisand

@cpu maintains this mirror.

Resolves https://github.com/jlund/streisand/issues/421