### PR TITLE
OpenVPN mirror fix

### DIFF
--- a/playbooks/roles/streisand-mirror/vars/openvpn.yml
+++ b/playbooks/roles/streisand-mirror/vars/openvpn.yml
@@ -4,8 +4,8 @@
 openvpn_mirror_location: "{{ streisand_mirror_location }}/openvpn"
 openvpn_mirror_href_base: "/mirror/openvpn"
 
-openvpn_samuli_seppanen_key_id: "0x12F5F7B42F2B01E7"
-openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = F554 A368 7412 CFFE BDEF  E0A3 12F5 F7B4 2F2B 01E7"
+openvpn_samuli_seppanen_key_id: "0x29584D9F40864578"
+openvpn_samuli_seppanen_expected_fingerprint: "Key fingerprint = 6D04 F8F1 B017 3111 F499  795E 2958 4D9F 4086 4578"
 
 openvpn_base_download_url: "https://build.openvpn.net/downloads/releases/latest"
 


### PR DESCRIPTION
Due to some [CDN related issues](http://community.openvpn.net/openvpn/wiki/release-packages-2.4.3-2.3.17), OpenVPN's latest releases are now being signed with GPG key ID `0x29584D9F40864578`.

This PR updates the OpenVPN mirroring task to reflect this change (once more).

Resolves #811 