### PR TITLE
Restore the unconditional ec2-security-group tasks.

### DIFF
--- a/playbooks/roles/ec2-security-group/tasks/main.yml
+++ b/playbooks/roles/ec2-security-group/tasks/main.yml
@@ -61,6 +61,16 @@
         from_port: "{{ openvpn_port_udp }}"
         to_port: "{{ openvpn_port_udp }}"
         cidr_ip: 0.0.0.0/0
+      # Shadowsocks
+      # ---
+      - proto: tcp
+        from_port: "{{ shadowsocks_server_port }}"
+        to_port: "{{ shadowsocks_server_port }}"
+        cidr_ip: 0.0.0.0/0
+      - proto: udp
+        from_port: "{{ shadowsocks_server_port }}"
+        to_port: "{{ shadowsocks_server_port }}"
+        cidr_ip: 0.0.0.0/0
       # SSH
       # ---
       - proto: tcp
@@ -85,50 +95,14 @@
         from_port: "{{ tor_obfs4_port }}"
         to_port: "{{ tor_obfs4_port }}"
         cidr_ip: 0.0.0.0/0
+      # WireGuard
+      # ---
+      - proto: udp
+        from_port: "{{ wireguard_port }}"
+        to_port: "{{ wireguard_port }}"
+        cidr_ip: 0.0.0.0/0
     rules_egress:
       - proto: all
         from_port: 1
         to_port: 65535
         cidr_ip: 0.0.0.0/0
-
-# Shadowsocks
-# ---
-- name: Open the Shadowsocks ports in the EC2 security group
-  ec2_group:
-    name: "{{ aws_security_group }}"
-    description: Security group for Streisand
-    region: "{{ aws_region }}"
-    vpc_id: "{{ aws_vpc_id | default(omit) }}"
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
-    rules:
-      # Shadowsocks TCP
-      # ---
-      - proto: tcp
-        from_port: "{{ shadowsocks_server_port }}"
-        to_port: "{{ shadowsocks_server_port }}"
-        cidr_ip: 0.0.0.0/0
-      # Shadowsocks UDP
-      # ---
-      - proto: udp
-        from_port: "{{ shadowsocks_server_port }}"
-        to_port: "{{ shadowsocks_server_port }}"
-        cidr_ip: 0.0.0.0/0
-  when: streisand_shadowsocks_enabled
-
-# WireGuard
-# ---
-- name: Open the WireGuard ports in the EC2 security group
-  ec2_group:
-    name: "{{ aws_security_group }}"
-    description: Security group for Streisand
-    region: "{{ aws_region }}"
-    vpc_id: "{{ aws_vpc_id | default(omit) }}"
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
-    rules:
-      - proto: udp
-        from_port: "{{ wireguard_port }}"
-        to_port: "{{ wireguard_port }}"
-        cidr_ip: 0.0.0.0/0
-  when: streisand_wireguard_enabled


### PR DESCRIPTION
As part of the modularization work the ec2-security-group task that
adds rules for each of the service ports was broken into three tasks:

1. a task for all of the unmodular ports.
2. a task that opened Shadowsocks ports when
   `streisand_shadowsocks_enabled` was true
3. a task that opened Wireguard ports when
   `streisand_wireguard_enabled` was true.

This design assumed that multiple `ec2_group` invocations was additive,
that is, that the three tasks would add to the same security group.
Instead the last `ec2_group` task is the only one that is used, in
effect only opening the Wireguard port for a default install.

I suspect there is a way to properly open only the required ports based
on the `enabled` vars but in the interest of fixing a regression on
master quickly this PR restores the unconditional EC2 security group
role with one `ec2_group` task.

This has the result of opening ports for Wireguard & Shadowsocks on EC2
when those services aren't installed. This isn't _ideal_, but since we
already ship `ufw` there isn't significant security impact since the
host machine will drop traffic to these ports regardless

I will investigate better options this weekend. Apologies for the
regression!

Resolves #810