### PR TITLE
Add an iOS/OS X .mobileconfig file for L2TP

### DIFF
--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -64,9 +64,9 @@
   register: ipsec_preshared_key
 
 - name: Register the IPsec pre-shared key as base64
-  command: cat {{ ipsec_preshared_key_file }} | base64
+  shell: cat {{ ipsec_preshared_key_file }} | tr -d '\n' | base64
   register: ipsec_preshared_key_base64
-  
+
 - name: Generate IPsec secrets file
   template:
     src: ipsec.secrets.j2
@@ -179,7 +179,7 @@
 - name: Get a UUID generator with an explicit random function.
   apt:
     name: uuid
-  
+
 - name: Generate a UUID for this Apple .mobileconfig package
   shell: uuid -v4
   register: l2tp_mobileconfig_package_uuid
@@ -192,5 +192,3 @@
   template:
     src: streisand.mobileconfig.j2
     dest: "{{ l2tp_ipsec_gateway_location }}/streisand.mobileconfig"
-
-    

--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -180,11 +180,11 @@
   apt:
     name: uuid
 
-- name: Generate a UUID for this Apple .mobileconfig package
+- name: Generate a UUID for the Apple .mobileconfig package
   shell: uuid -v4
   register: l2tp_mobileconfig_package_uuid
 
-- name: Generate a UUID for this VPN for the Apple .mobileconfig package
+- name: Generate a UUID for the VPN for the Apple .mobileconfig package
   shell: uuid -v4
   register: l2tp_mobileconfig_vpn_uuid
 

--- a/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
@@ -45,21 +45,22 @@ You can verify that your traffic is being routed properly by [looking up your IP
 <a name="osx"></a>
 ### OS X ###
 
-There are two ways to configure the OS X L2TP VPN to connect to this Streisand server. The easier is to install an OS X *profile* containing the VPN definition. You can also set up the VPN manually.
+There are two ways to configure the OS X L2TP VPN to connect to this Streisand server. The easier is to install an OS X *profile* containing the VPN definition. You can also set up the VPN [manually](#osx_manual).
 
 To install via profile, click here:
 
  [__`streisand.mobileconfig`__](streisand.mobileconfig)
 
-If the file is downloaded successfully, OS X will ask if you want to install it. Click "Continue" to do so.
+If the file is downloaded successfully, OS X will ask if you want to install it. Click *Continue* to do so. Once installed, you can [activate the VPN](#osx_connect).
 
 Your installed profiles are managed in the System Preferences "Profiles" pane. Streisand's profiles may be removed at any time.
 
 Please note that profiles are very powerful, and you should be careful installing unknown profiles. OS X will display which features would be configured by a profile before you install it. In Streisand's case, the only feature will be "VPN Service".
 
+<a name="osx_manual"></a>
 If you'd prefer to set it up manually:
 
-1. Open System Preferences and go to the Network section.
+1. Open *System Preferences* and go to the *Network* section.
 1. Click the *+* button in the lower-left corner of the window.
 1. Select *VPN* from the *Interface* drop-down menu.
 1. Select *L2TP over IPSec* from the *VPN Type* drop-down menu.
@@ -76,7 +77,14 @@ If you'd prefer to set it up manually:
 1. Click the *TCP/IP* tab, and make sure *Link-local only* is selected in the *Configure IPv6* section.
 1. Click *OK* to close the Advanced settings, and then click *Apply* to save the VPN connection information.
 
-You can connect to the VPN using the VPN icon in the menu bar, or by selecting the VPN in the Network section of System Preferences and choosing *Connect*. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
+<a name="osx_connect"></a>
+#### Connecting on OS X ####
+To activate the VPN:
+
+* Use the VPN icon in the menu bar, or
+* Open *Network* in *System Preferences*. Click on the Streisand entry in the list of connections. There's a *Connect* button there.
+
+You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux"></a>
 ### Linux ###
@@ -110,18 +118,19 @@ L2TP/IPsec connections are not supported out-of-the-box on most Linux distributi
 <a name="ios"></a>
 ### iOS ###
 
-There are two ways to configure the iOS L2TP VPN to connect to this Streisand server. The easier is to install an iOS *profile* containing the VPN definition. You can also set up the VPN manually.
+There are two ways to configure the iOS L2TP VPN to connect to this Streisand server. The easier is to install an iOS *profile* containing the VPN definition. You can also set up the VPN [manually](#ios_manual).
 
 To install via profile, tap here:
 
  [__`streisand.mobileconfig`__](streisand.mobileconfig)
 
-If the file is downloaded successfully, iOS will will ask if you want to install the profile. Click "Install". iOS will prompt for your PIN to confirm it's you installing a profile. iOS will then (correctly) warn you that a VPN server like Streisand could monitor your network traffic. If this is acceptable to you, click "Install" again.
+If the file is downloaded successfully, iOS will will ask if you want to install the profile. Click *Install*. iOS will prompt for your PIN to confirm it's you installing a profile. iOS will then (correctly) warn you that a VPN server like Streisand could monitor your network traffic. If this is acceptable to you, click *Install* again. Once installed you can [activate the VPN](#ios_connect).
 
-Your installed profiles are managed in iOS Settings. Near the bottom of the "General" settings, there is a "Profiles" sub-menu listing all your installed profiles. Streisand's profiles may be removed at any time.
+Your installed profiles are managed in iOS *Settings*. Near the bottom of the *General* settings, there is a *Profiles* sub-menu listing all your installed profiles. Streisand's profiles may be removed at any time.
 
 Please note that profiles are very powerful, and you should be careful installing unknown profiles. iOS will display which features would be configured by a profile before you install it. In Streisand's case, the only feature will be "VPN Service".
 
+<a name="ios_manual"></a>
 If you'd prefer to set it up manually:
 
 1. Go to Settings -> General -> VPN.
@@ -134,6 +143,12 @@ If you'd prefer to set it up manually:
 1. Tap *Password* and enter `{{ chap_password.stdout }}`.
 1. Tap *Secret* and enter `{{ ipsec_preshared_key.stdout }}`.
 1. Tap *Done*.
+
+<a name="ios_connect"></a>
+#### Connecting on iOS ####
+To activate the VPN:
+
+1. Go to *Settings* -> *General* -> *VPN*.
 1. Slide the *VPN* switch on.
 1. Once connected, you will see a VPN icon in the status bar. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 

--- a/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
@@ -45,9 +45,17 @@ You can verify that your traffic is being routed properly by [looking up your IP
 <a name="osx"></a>
 ### OS X ###
 
-There are two ways to configure the OS X L2TP VPN to connect to this Streisand server. The easiest is to install an OS X *profile* containing the VPN definition. You can also set it up manually.
+There are two ways to configure the OS X L2TP VPN to connect to this Streisand server. The easier is to install an OS X *profile* containing the VPN definition. You can also set up the VPN manually.
 
-The profile is [available here](streisand.mobileconfig).
+To install via profile, click here:
+
+ [__`streisand.mobileconfig`__](streisand.mobileconfig)
+
+If the file is downloaded successfully, OS X will ask if you want to install it. Click "Continue" to do so.
+
+Your installed profiles are managed in the System Preferences "Profiles" pane. Streisand's profiles may be removed at any time.
+
+Please note that profiles are very powerful, and you should be careful installing unknown profiles. OS X will display which features would be configured by a profile before you install it. In Streisand's case, the only feature will be "VPN Service".
 
 If you'd prefer to set it up manually:
 
@@ -102,9 +110,17 @@ L2TP/IPsec connections are not supported out-of-the-box on most Linux distributi
 <a name="ios"></a>
 ### iOS ###
 
-There are two ways to configure the iOS L2TP VPN to connect to this Streisand server. The easiest is to install an iOS *profile* containing the VPN definition. You can also set it up manually.
+There are two ways to configure the iOS L2TP VPN to connect to this Streisand server. The easier is to install an iOS *profile* containing the VPN definition. You can also set up the VPN manually.
 
-The profile is [available here](streisand.mobileconfig).
+To install via profile, tap here:
+
+ [__`streisand.mobileconfig`__](streisand.mobileconfig)
+
+If the file is downloaded successfully, iOS will will ask if you want to install the profile. Click "Install". iOS will prompt for your PIN to confirm it's you installing a profile. iOS will then (correctly) warn you that a VPN server like Streisand could monitor your network traffic. If this is acceptable to you, click "Install" again.
+
+Your installed profiles are managed in iOS Settings. Near the bottom of the "General" settings, there is a "Profiles" sub-menu listing all your installed profiles. Streisand's profiles may be removed at any time.
+
+Please note that profiles are very powerful, and you should be careful installing unknown profiles. iOS will display which features would be configured by a profile before you install it. In Streisand's case, the only feature will be "VPN Service".
 
 If you'd prefer to set it up manually:
 

--- a/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/instructions.md.j2
@@ -44,6 +44,13 @@ You can verify that your traffic is being routed properly by [looking up your IP
 
 <a name="osx"></a>
 ### OS X ###
+
+There are two ways to configure the OS X L2TP VPN to connect to this Streisand server. The easiest is to install an OS X *profile* containing the VPN definition. You can also set it up manually.
+
+The profile is [available here](streisand.mobileconfig).
+
+If you'd prefer to set it up manually:
+
 1. Open System Preferences and go to the Network section.
 1. Click the *+* button in the lower-left corner of the window.
 1. Select *VPN* from the *Interface* drop-down menu.
@@ -94,6 +101,13 @@ L2TP/IPsec connections are not supported out-of-the-box on most Linux distributi
 
 <a name="ios"></a>
 ### iOS ###
+
+There are two ways to configure the iOS L2TP VPN to connect to this Streisand server. The easiest is to install an iOS *profile* containing the VPN definition. You can also set it up manually.
+
+The profile is [available here](streisand.mobileconfig).
+
+If you'd prefer to set it up manually:
+
 1. Go to Settings -> General -> VPN.
 1. Tap *Add VPN Configuration...*.
 1. Tap *Type*.

--- a/playbooks/roles/l2tp-ipsec/templates/streisand.mobileconfig.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/streisand.mobileconfig.j2
@@ -17,7 +17,7 @@
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 	<key>PayloadDisplayName</key>
-	<string>Streisand L2TP config for({{ streisand_server_name }})</string>
+	<string>Streisand L2TP config for {{ streisand_server_name }}</string>
 	<key>PayloadDescription</key>
 	<string>This profile is a VPN configuration for the Streisand server "{{ streisand_server_name }}" running at {{ streisand_ipv4_address }}. It uses Apple's native L2TP/IPsec protocol. This profile can be removed at any time.</string>
 	<key>PayloadContent</key>

--- a/playbooks/roles/l2tp-ipsec/templates/streisand.mobileconfig.j2
+++ b/playbooks/roles/l2tp-ipsec/templates/streisand.mobileconfig.j2
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>PayloadIdentifier</key>
-	<string>streisand.mdm.{{ l2tp_mobileconfig_package_uuid }}.alacarte</string>
+	<string>streisand.mdm.{{ l2tp_mobileconfig_package_uuid.stdout }}.alacarte</string>
 	<key>PayloadRemovalDisallowed</key>
 	<false/>
 	<key>PayloadScope</key>
@@ -11,15 +11,15 @@
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
-	<string>{{ l2tp_mobileconfig_package_uuid }}</string>
+	<string>{{ l2tp_mobileconfig_package_uuid.stdout }}</string>
 	<key>PayloadOrganization</key>
-	<string>Streisand Effects Department</string>
+	<string>Streisand Effect Department</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 	<key>PayloadDisplayName</key>
-	<string>Streisand L2TP ({{ streisand_server_name }})</string>
+	<string>Streisand L2TP config for({{ streisand_server_name }})</string>
 	<key>PayloadDescription</key>
-	<string>This is a VPN configuration for the Streisand server "{{ streisand_server_name }}" running at {{ streisand_ipv4_address }}. It uses Apple's native using L2TP/IPsec protocol. This profile can be removed at any time.</string>
+	<string>This profile is a VPN configuration for the Streisand server "{{ streisand_server_name }}" running at {{ streisand_ipv4_address }}. It uses Apple's native L2TP/IPsec protocol. This profile can be removed at any time.</string>
 	<key>PayloadContent</key>
 	<array>
 		<dict>
@@ -28,9 +28,9 @@
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 			<key>PayloadIdentifier</key>
-			<string>streisand.mdm.{{ l2tp_mobileconfig_package_uuid }}.{{ l2tp_mobileconfig_vpn_uuid }}</string>
+			<string>streisand.mdm.{{ l2tp_mobileconfig_package_uuid.stdout }}.{{ l2tp_mobileconfig_vpn_uuid.stdout }}</string>
 			<key>PayloadUUID</key>
-			<string>{{ l2tp_mobileconfig_vpn_uuid }}</string>
+			<string>{{ l2tp_mobileconfig_vpn_uuid.stdout }}</string>
 			<key>PayloadEnabled</key>
 			<true/>
 			<key>PayloadDisplayName</key>
@@ -60,7 +60,7 @@
 				<integer>0</integer>
 				<key>SharedSecret</key>
 				<data>
-				{{ ipsec_preshared_key_base64|e }}
+				{{ ipsec_preshared_key_base64.stdout|e }}
 				</data>
 			</dict>
 			<key>ikev2IKESADiffieHellmanGroup</key>


### PR DESCRIPTION
Disclaimer: I am not an ansible person; would love someone to clean up.

The `.mobileconfig` generated is very similar to what OS X Server emits. Note that we can't configure "AlwaysOn" VPNs because that apparently requires a "managed" device, and nobody really wants that.

See https://developer.apple.com/library/content/featuredarticles/iPhoneConfigurationProfileRef/Introduction/Introduction.html for more information on these config files.

This PR addresses half of #136 (we still need to generate some mobileconfig containing our server certs) and I am ignoring the similar #512 until I understand what that “connect on demand” checkbox really does. (Probably not what you’d think.)