### PR TITLE
Set GCE `ansible_user` to `root` to match SSH key metadata.

### DIFF
--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -28,7 +28,6 @@
   add_host:
     name: "{{ streisand_server.instance_data[0].public_ip }}"
     groups: streisand-host
-    ansible_become: yes
 
 - name: Set the streisand_ipv4_address variable
   set_fact:

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -28,7 +28,6 @@
   add_host:
     name: "{{ streisand_server.instance_data[0].public_ip }}"
     groups: streisand-host
-    ansible_user: root
     ansible_become: yes
 
 - name: Set the streisand_ipv4_address variable

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -28,7 +28,7 @@
   add_host:
     name: "{{ streisand_server.instance_data[0].public_ip }}"
     groups: streisand-host
-    ansible_user: ubuntu
+    ansible_user: root
     ansible_become: yes
 
 - name: Set the streisand_ipv4_address variable


### PR DESCRIPTION
Prior to this commit the GCE genesis role was setting the `ansible_user`
to `ubuntu`. This appears to be a mistake since in the earlier `gce`
task it adds the SSH key under the `root` user.

In testing a GCE provision recently I noticed that the cloud-init task
would fail with an SSH "Permission denied (publickey)" error. Similar
`raw` tasks would fail if the cloud-init include was commented out.

In practice using `root` as the `ansible_user` for GCE allows
provisioning to complete without error.

It's not clear to me why this didn't break before since the
`ansible_user` has been static for some time... Mysterious!