### PR TITLE
Enable conditional rules for modular roles in EC2 Security Groups

### DIFF
--- a/playbooks/roles/ec2-security-group/tasks/main.yml
+++ b/playbooks/roles/ec2-security-group/tasks/main.yml
@@ -12,7 +12,7 @@
   pause:
     seconds: 15
 
-- name: Open all of the necessary ports across every service in the EC2 security group
+- name: Open necessary ports across supported services in the EC2 security group
   ec2_group:
     name: "{{ aws_security_group }}"
     description: Security group for Streisand
@@ -61,16 +61,6 @@
         from_port: "{{ openvpn_port_udp }}"
         to_port: "{{ openvpn_port_udp }}"
         cidr_ip: 0.0.0.0/0
-      # Shadowsocks
-      # ---
-      - proto: tcp
-        from_port: "{{ shadowsocks_server_port }}"
-        to_port: "{{ shadowsocks_server_port }}"
-        cidr_ip: 0.0.0.0/0
-      - proto: udp
-        from_port: "{{ shadowsocks_server_port }}"
-        to_port: "{{ shadowsocks_server_port }}"
-        cidr_ip: 0.0.0.0/0
       # SSH
       # ---
       - proto: tcp
@@ -83,26 +73,81 @@
         from_port: "{{ stunnel_remote_port }}"
         to_port: "{{ stunnel_remote_port }}"
         cidr_ip: 0.0.0.0/0
+    rules_egress:
+      - proto: all
+        from_port: 1
+        to_port: 65535
+        cidr_ip: 0.0.0.0/0
+
+# Shadowsocks
+# ---
+- name: Open the Shadowsocks ports in the EC2 security group
+  ec2_group:
+    name: "{{ aws_security_group }}"
+    description: Security group for Streisand
+    region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id | default(omit) }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    purge_rules: no
+    purge_rules_egress: no
+    rules:
+      # Shadowsocks TCP
+      # ---
+      - proto: tcp
+        from_port: "{{ shadowsocks_server_port }}"
+        to_port: "{{ shadowsocks_server_port }}"
+        cidr_ip: 0.0.0.0/0
+      # Shadowsocks UDP
+      # ---
+      - proto: udp
+        from_port: "{{ shadowsocks_server_port }}"
+        to_port: "{{ shadowsocks_server_port }}"
+        cidr_ip: 0.0.0.0/0
+  when: streisand_shadowsocks_enabled
+
+# Tor
+# ---
+- name: Open the Tor ports in the EC2 security group
+  ec2_group:
+    name: "{{ aws_security_group }}"
+    description: Security group for Streisand
+    region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id | default(omit) }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    purge_rules: no
+    purge_rules_egress: no
+    rules:
       # Tor
       # ---
       - proto: tcp
         from_port: "{{ tor_orport }}"
         to_port: "{{ tor_orport }}"
         cidr_ip: 0.0.0.0/0
-      # Tor obfs4 port
+      # Tor obfs4
       # ---
       - proto: tcp
         from_port: "{{ tor_obfs4_port }}"
         to_port: "{{ tor_obfs4_port }}"
         cidr_ip: 0.0.0.0/0
-      # WireGuard
-      # ---
+  when: streisand_tor_enabled
+
+# WireGuard
+# ---
+- name: Open the WireGuard ports in the EC2 security group
+  ec2_group:
+    name: "{{ aws_security_group }}"
+    description: Security group for Streisand
+    region: "{{ aws_region }}"
+    vpc_id: "{{ aws_vpc_id | default(omit) }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    purge_rules: no
+    purge_rules_egress: no
+    rules:
       - proto: udp
         from_port: "{{ wireguard_port }}"
         to_port: "{{ wireguard_port }}"
         cidr_ip: 0.0.0.0/0
-    rules_egress:
-      - proto: all
-        from_port: 1
-        to_port: 65535
-        cidr_ip: 0.0.0.0/0
+  when: streisand_wireguard_enabled


### PR DESCRIPTION
This PR re-enables the functionality that was rolled back in #814. We can prevent the issues that were reported in #810 using the `purge_rules` and `purge_rules_egress` arguments. When these arguments are set to `no`, repeated invocations of the `ec2_group` module don't blow away existing inbound and outbound rules.