### PR TITLE
wireguard: use the new DNS setting

### DIFF
--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -28,4 +28,4 @@ WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plat
    `sudo wg-quick down wg0-client`
 
 #### Une note sur la configuration DNS ####
-Le fichier `wg0-client.conf` inlcure des commandes `PostUp` et `PostDown` simples qui utilisent `resolvconf` afin de diriger le trafic DNS vers le serveur dnsmasq qui est disponible via l'interface cryptée WireGuard à `{{ dnsmasq_wireguard_ip }}`. Bien que `resolvconf` soit un utilitaire commun, vous devrez peut-être modifier ces lignes pour votre distribution ou votre configuration réseau particulière.
+Le fichier `wg0-client.conf` inlcure la commande `DNS` qui utilise `resolvconf` afin de diriger le trafic DNS vers le serveur dnsmasq qui est disponible via l'interface cryptée WireGuard à `{{ dnsmasq_wireguard_ip }}`. Bien que `resolvconf` soit un utilitaire commun, vous devrez peut-être remplacer cette ligne avec `PostUp`/`PostDown` pour votre distribution ou votre configuration réseau particulière.

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -27,4 +27,4 @@ WireGuard is currently only available for Linux, but [cross-platform](https://ww
    `sudo wg-quick down wg0-client`
 
 #### A note on DNS configuration ####
-The `wg0-client.conf` file includes simple `PostUp` and `PostDown` commands that use resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to modify these lines for your distribution or particular network configuration.
+The `wg0-client.conf` file includes a `DNS` command that uses resolvconf to direct DNS traffic to the dnsmasq server that is available via the WireGuard encrypted interface at `{{ dnsmasq_wireguard_ip }}`. Although resolvconf is a common utility, you may need to use `PostUp`/`PostDown` with a different command for your distribution or particular network configuration.

--- a/playbooks/roles/wireguard/templates/wg0-client.conf.j2
+++ b/playbooks/roles/wireguard/templates/wg0-client.conf.j2
@@ -1,12 +1,13 @@
 [Interface]
 Address = 10.192.122.2/32
-# These PostUp and PostDown commands should work on most distributions,
-# but you may need to modify them if your network situation is unique.
-#
+# The use of DNS below effectively expands to:
+#   PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a tun.%i -m 0 -x
+#   PostDown = resolvconf -d tun.%i
+# If the use of resolvconf is not desirable, simply remove the DNS line
+# and use a variant of the PostUp/PostDown lines above.
 # The IP address of the DNS server that is available via the encrypted
 # WireGuard interface is {{ dnsmasq_wireguard_ip }}.
-PostUp = echo nameserver {{ dnsmasq_wireguard_ip }} | resolvconf -a tun.%i -m 0 -x
-PostDown = resolvconf -d tun.%i
+DNS = {{ dnsmasq_wireguard_ip }}
 PrivateKey = {{ wireguard_client_private_key }}
 
 [Peer]


### PR DESCRIPTION
This came out with 0.0.20170726, and merging it probably should depend on @EggieCode pushing the package to the Ubuntu PPA.