### PR TITLE
Optional tinyproxy

### DIFF
--- a/global_vars/vars.yml
+++ b/global_vars/vars.yml
@@ -11,5 +11,6 @@ streisand_openvpn_enabled: yes
 streisand_stunnel_enabled: yes
 streisand_tor_enabled: yes
 streisand_openconnect_enabled: yes
+streisand_tinyproxy_enabled: yes
 
 gpg_key_server_address: "x-hkp://pool.sks-keyservers.net"

--- a/playbooks/roles/monit/templates/monitrc.j2
+++ b/playbooks/roles/monit/templates/monitrc.j2
@@ -89,6 +89,7 @@ check file dnsmasq-bin with path /usr/sbin/dnsmasq
 check file dnsmasq-hosts with path /etc/hosts
    if changed timestamp then restart
 
+{% if streisand_tinyproxy_enabled %}
 
 # Tinyproxy
 check process tinyproxy with pidfile /var/run/tinyproxy/tinyproxy.pid
@@ -97,6 +98,7 @@ check process tinyproxy with pidfile /var/run/tinyproxy/tinyproxy.pid
    if failed host 127.0.0.1 port 8888 type tcp then restart
    # if 5 restarts within 5 cycles then timeout
 
+{% endif %}
 
 # sslh
 check process sslh with pidfile /var/run/sslh/sslh.pid

--- a/playbooks/roles/ssh/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh/templates/instructions-fr.md.j2
@@ -6,7 +6,9 @@ Tunnel SSH
   * [Windows](#windows)
   * [Linux et OS X](#linux-and-osx)
   * [Linux et OS X (alternatif)](#linux-and-osx-alternate)
-
+{% if streisand_tinyproxy_enabled %}
+  * [Androïde](#android)
+{% endif %}
 
 <a name="windows"></a>
 ### Windows ###
@@ -114,6 +116,7 @@ Sshuttle offre des performances beaucoup plus rapides et est plus facile à conf
    `{{ ssh_server_fingerprints.results[1].stdout }}`
 1. Vous êtes maintenant connecté à un proxy SOCKS qui est prêt à transférer votre trafic chiffré via SSH. L'étape suivante consiste à configurer votre navigateur Web pour l'utiliser. Vous pouvez suivre les mêmes instructions contenues dans la section Windows ci-dessus pour configurer Firefox pour acheminer son trafic via le proxy SOCKS.
 
+{% if streisand_tinyproxy_enabled %}
 <a name="android"></a>
 ### Androïde ###
 1. Installez [SSH persistent tunnels](https://play.google.com/store/apps/details?id=org.ayal.SPT&hl=fr) par Shai Ayal. Cette application permet de transférer facilement plusieurs ports via un tunnel SSH, et fonctionne assez bien pour s'assurer que les tunnels restent actifs même lorsque vous changez régulièrement entre LTE, 3G et WiFi. L'application est [open source](https://bitbucket.org/ayal_org/ssh-persistent-tunnel/) et peut être compilée gratuitement, mais la version Play Store coûte $1,50 (USD).
@@ -172,3 +175,4 @@ Certaines applications vous permettent de rendre ces paramètres persistants pou
 5. Définissez la valeur de *network.proxy.socks\_port* à `1080`.
 6. Définissez la valeur de *network.proxy.socks\_remote\_dns* à `true`.
 7. Définissez la valeur de *network.proxy.type* à `1`.
+{% endif %}

--- a/playbooks/roles/ssh/templates/instructions.md.j2
+++ b/playbooks/roles/ssh/templates/instructions.md.j2
@@ -6,7 +6,9 @@ SSH Tunnel
   * [Windows](#windows)
   * [Linux and OS X](#linux-and-osx)
   * [Linux and OS X (alternate)](#linux-and-osx-alternate)
+{% if streisand_tinyproxy_enabled %}
   * [Android](#android)
+{% endif %}
 
 <a name="windows"></a>
 ### Windows ###
@@ -114,7 +116,7 @@ Sshuttle offers significantly faster performance and is easier to set up, but th
 
    `{{ ssh_server_fingerprints.results[1].stdout }}`
 1. You are now connected and have a SOCKS proxy up and running that is ready to forward encrypted traffic through SSH. The next step is to configure your web browser to use it. You can follow the same instructions contained in the Windows section above to configure Firefox to route its traffic through the SOCKS proxy.
-
+{% if streisand_tinyproxy_enabled %}
 <a name="android"></a>
 ### Android ###
 1. Install [SSH persistent tunnels](https://play.google.com/store/apps/details?id=org.ayal.SPT) by Shai Ayal. This application makes it easy to forward multiple ports through an SSH tunnel, and it does a decent job of ensuring that the tunnels remain active even when you switch back and forth regularly between LTE, 3G, and WiFi. The app is [open source](https://code.google.com/p/ssh-persistent-tunnel/) and can be compiled for free, but the Play Store version costs $1.50.
@@ -173,3 +175,4 @@ Some applications allow you to make these settings persistent for all networks. 
 5. Set the value of *network.proxy.socks\_port* to `1080`.
 6. Set the value of *network.proxy.socks\_remote\_dns* to `true`.
 7. Set the value of *network.proxy.type* to `1`.
+{% endif %}

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -21,7 +21,8 @@
     - role: shadowsocks
       when: streisand_shadowsocks_enabled
     - ssh
-    - tinyproxy
+    - role: tinyproxy
+      when: streisand_tinyproxy_enabled
     # tor-bridge is skipped in our full Ansible run on Travis CI due to
     # connectivity issues.
     - role: tor-bridge


### PR DESCRIPTION
This PR modifies Streisand to make the tinyproxy role optional, which can be configured by modifying the `streisand_tinyproxy_enabled` to `no`, located in `global_vars/vars.yml`.

Updates #746.