### PR TITLE
Variables missing for modular Streisand

### DIFF
--- a/playbooks/group_vars/all
+++ b/playbooks/group_vars/all
@@ -1,5 +1,17 @@
 ---
+upstream_dns_servers:
+  - 8.8.8.8
+  - 208.67.222.222
+
 streisand_ci: no
 streisand_noninteractive: no
+streisand_client_test: no
+
+streisand_shadowsocks_enabled: yes
+streisand_wireguard_enabled: yes
+streisand_openvpn_enabled: yes
+streisand_stunnel_enabled: yes
+streisand_tor_enabled: yes
+streisand_openconnect_enabled: yes
 
 gpg_key_server_address: "x-hkp://pool.sks-keyservers.net"


### PR DESCRIPTION
The new modular Streisand expects some configuration variables to be set and they aren't.