### PR TITLE
Update documentation to reflect the new WireGuard domain

### DIFF
--- a/README-fr.md
+++ b/README-fr.md
@@ -78,7 +78,7 @@ Services fournis
   * Les règles de pare-feu sont configurées pour chaque service et tout trafic qui est envoyé vers un port non autorisé sera bloqué.
 * [unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates)
   * Votre serveur Streisand est configuré pour installer automatiquement de nouvelles mises à jour de sécurité.
-* [WireGuard](https://www.wireguard.io/)
+* [WireGuard](https://www.wireguard.com/)
   * Les utilisateurs Linux peuvent profiter d'un VPN de nouvelle génération qui est simple mais à la même fois moderne, basé dans le noyau, et utilise des principes cryptographiques modernes que toutes les autres solutions VPN ne fournissent pas.
 
 Installation
@@ -188,7 +188,7 @@ S'il ya quelque chose que vous pensez que Streisand devrait faire, ou si vous tr
 
 Remerciements
 -------------
-[Jason A. Donenfeld](https://www.zx2c4.com/) mérite beaucoup de crédit pour être assez courageux à réimaginer ce qu'est un VPN moderne devrait ressembler et pour mettre au monde quelque chose aussi épatant que [WireGuard](https://www.wireguard.io/). Il a mes sincères remerciements pour toute son aide, patience et ses commentaires.
+[Jason A. Donenfeld](https://www.zx2c4.com/) mérite beaucoup de crédit pour être assez courageux à réimaginer ce qu'est un VPN moderne devrait ressembler et pour mettre au monde quelque chose aussi épatant que [WireGuard](https://www.wireguard.com/). Il a mes sincères remerciements pour toute son aide, patience et ses commentaires.
 
 [Corban Raun](https://github.com/CorbanR) à eu la gentillesse de me prêter un ordinateur portable Windows qui m'a permi de tester et d'affiner les instructions pour cette plate-forme, aussi bien qu'il était un grand partisan du projet dès le début.
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Services Provided
   * Firewall rules are configured for every service, and any traffic that is sent to an unauthorized port will be blocked.
 * [unattended-upgrades](https://help.ubuntu.com/community/AutomaticSecurityUpdates)
   * Your Streisand server is configured to automatically install new security updates.
-* [WireGuard](https://www.wireguard.io/)
+* [WireGuard](https://www.wireguard.com/)
   * Linux users can take advantage of this next-gen, simple, kernel-based, state-of-the-art VPN that also happens to be ridiculously fast and uses modern cryptographic principles that all other highspeed VPN solutions lack.
 
 Installation
@@ -195,7 +195,7 @@ If there is something that you think Streisand should do, or if you find a bug i
 
 Acknowledgements
 ----------------
-[Jason A. Donenfeld](https://www.zx2c4.com/) deserves a lot of credit for being brave enough to reimagine what a modern VPN should look like and for coming up with something as good as [WireGuard](https://www.wireguard.io/). He has my sincere thanks for all of his patient help and high-quality feedback.
+[Jason A. Donenfeld](https://www.zx2c4.com/) deserves a lot of credit for being brave enough to reimagine what a modern VPN should look like and for coming up with something as good as [WireGuard](https://www.wireguard.com/). He has my sincere thanks for all of his patient help and high-quality feedback.
 
 [Corban Raun](https://github.com/CorbanR) was kind enough to lend me a Windows laptop that let me test and refine the instructions for that platform, and he was a big supporter of the project from the very beginning.
 

--- a/playbooks/roles/wireguard/templates/instructions-fr.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions-fr.md.j2
@@ -1,15 +1,15 @@
 WireGuard
 ---------
 
-Si vous êtes un utilisateur Linux, [WireGuard](https://www.wireguard.io/) est presque certainement la meilleure option de connexion que Streisand fournit. Ceci est dû à sa [performance incroyable](https://www.wireguard.io/performance/), [cryptographie de pointe](https://www.wireguard.io/protocol/), et beaucoup, beaucoup d'autres avantages.
+Si vous êtes un utilisateur Linux, [WireGuard](https://www.wireguard.com/) est presque certainement la meilleure option de connexion que Streisand fournit. Ceci est dû à sa [performance incroyable](https://www.wireguard.com/performance/), [cryptographie de pointe](https://www.wireguard.com/protocol/), et beaucoup, beaucoup d'autres avantages.
 
-WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plateforme](https://www.wireguard.io/xplatform/) et les implémentations portables sont en cours de développement.
+WireGuard n'est actuellement disponible que pour Linux, mais support [multi-plateforme](https://www.wireguard.com/xplatform/) et les implémentations portables sont en cours de développement.
 
 ---
 
 <a name="linux"></a>
 ### Linux ###
-1. [Installer WireGuard](https://www.wireguard.io/install/)
+1. [Installer WireGuard](https://www.wireguard.com/install/)
 1. Téléchargez le fichier de configuration du client:
    * [wg0-client.conf](/wireguard/wg0-client.conf)
 1. Définir les autorisations sur le fichier de configuration du client:

--- a/playbooks/roles/wireguard/templates/instructions.md.j2
+++ b/playbooks/roles/wireguard/templates/instructions.md.j2
@@ -1,15 +1,15 @@
 WireGuard
 ---------
 
-If you are a Linux user, [WireGuard](https://www.wireguard.io/) is almost certainly the best connection option that Streisand provides. This is due to its [incredible performance](https://www.wireguard.io/performance/), [class-leading cryptography](https://www.wireguard.io/protocol/), and many, many other benefits.
+If you are a Linux user, [WireGuard](https://www.wireguard.com/) is almost certainly the best connection option that Streisand provides. This is due to its [incredible performance](https://www.wireguard.com/performance/), [class-leading cryptography](https://www.wireguard.com/protocol/), and many, many other benefits.
 
-WireGuard is currently only available for Linux, but [cross-platform](https://www.wireguard.io/xplatform/) and portable implementations are under active development.
+WireGuard is currently only available for Linux, but [cross-platform](https://www.wireguard.com/xplatform/) and portable implementations are under active development.
 
 ---
 
 <a name="linux"></a>
 ### Linux ###
-1. [Install WireGuard](https://www.wireguard.io/install/)
+1. [Install WireGuard](https://www.wireguard.com/install/)
 1. Download the client configuration file:
    * [wg0-client.conf](/wireguard/wg0-client.conf)
 1. Set permissions on the client configuration file:


### PR DESCRIPTION
The WireGuard project is moving from wireguard.io to wireguard.com:
  https://lists.zx2c4.com/pipermail/wireguard/2017-July/001569.html