### PR TITLE
Refactor the Nginx restart tasks to support modularity

### DIFF
--- a/playbooks/roles/nginx/tasks/main.yml
+++ b/playbooks/roles/nginx/tasks/main.yml
@@ -26,7 +26,6 @@
     owner: root
     group: root
     mode: 0644
-  notify: Restart Nginx
 
 - name: Set up Nginx vhost directories
   file:

--- a/playbooks/roles/streisand-gateway/handlers/main.yml
+++ b/playbooks/roles/streisand-gateway/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart Nginx
+- name: Restart Nginx for the Gateway vhost
   service:
     name: nginx
     state: restarted

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -97,7 +97,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: Restart Nginx
+  notify: Restart Nginx for the Gateway vhost
 
 - name: Enable the virtual host
   file:

--- a/playbooks/roles/tor-bridge/handlers/main.yml
+++ b/playbooks/roles/tor-bridge/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: Restart Nginx for the Tor hidden service vhost
+  service:
+    name: nginx
+    state: restarted

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -104,7 +104,7 @@
     owner: root
     group: root
     mode: 0644
-  notify: Restart Nginx
+  notify: Restart Nginx for the Tor hidden service vhost
 
 - name: Enable the virtual host
   file:


### PR DESCRIPTION
Previously, the Nginx restart handler was located in the Nginx role. The `tor-bridge` and `streisand-gateway` roles declared a dependency on the Nginx role and notified the same handler for their respective vhost template tasks.

The issue with this approach in a modular world is that the Tor role runs prior to the Gateway role. The Nginx role (and its handler) are skipped as declared dependencies of the Tor role if the `streisand_tor_enabled` variable is set to 'no'. Later on, the Nginx tasks run successfully when the Gateway role also declares a dependency on Nginx. However, Ansible still treats the handler as having been skipped and won't execute the restart task because handlers only run once and the first skip takes precedence.

This PR moves the handlers into each role with unique names (which also helps sidestep another issue as well: ansible/ansible#18594).