### PR TITLE
Update the Monit config to use the `service` init wrapper

### DIFF
--- a/playbooks/roles/monit/templates/monitrc.j2
+++ b/playbooks/roles/monit/templates/monitrc.j2
@@ -13,8 +13,8 @@ set httpd port 2812 and
 
 # Nginx
 check process nginx with pidfile /var/run/nginx.pid
-  start program = "/etc/init.d/nginx start"
-  stop  program = "/etc/init.d/nginx stop"
+  start program = "/usr/sbin/service nginx start"
+  stop  program = "/usr/sbin/service nginx stop"
   if cpu is greater than 40% for 2 cycles then alert
   if cpu > 60% for 5 cycles then restart
   if 10 restarts within 10 cycles then timeout
@@ -26,23 +26,23 @@ check process nginx with pidfile /var/run/nginx.pid
 
 # OpenVPN
 check process vpn-network with pidfile /var/run/openvpn/server.pid
-   start program = "/etc/init.d/openvpn start server"
-   stop program = "/etc/init.d/openvpn stop server"
+   start program = "/usr/sbin/service openvpn start server"
+   stop program = "/usr/sbin/service openvpn stop server"
 
 check host tun0 with address 10.8.0.1
-    start program = "/etc/init.d/openvpn start server"
-    stop program = "/etc/init.d/openvpn stop server"
+    start program = "/usr/sbin/service openvpn start server"
+    stop program = "/usr/sbin/service openvpn stop server"
     if failed
         icmp type echo count 5 with timeout 15 seconds
     then restart
 
 check process vpn-network-udp with pidfile /var/run/openvpn/server-udp.pid
-   start program = "/etc/init.d/openvpn start server-udp"
-   stop program = "/etc/init.d/openvpn stop server-udp"
+   start program = "/usr/sbin/service openvpn start server-udp"
+   stop program = "/usr/sbin/service openvpn stop server-udp"
 
 check host tun1 with address 10.9.0.1
-    start program = "/etc/init.d/openvpn start server-udp"
-    stop program = "/etc/init.d/openvpn stop server-udp"
+    start program = "/usr/sbin/service openvpn start server-udp"
+    stop program = "/usr/sbin/service openvpn stop server-udp"
     if failed
         icmp type echo count 5 with timeout 15 seconds
     then restart
@@ -50,8 +50,8 @@ check host tun1 with address 10.9.0.1
 {% if streisand_stunnel_enabled %}
 # stunnel
 check process stunnel4 with pidfile /var/run/stunnel4.pid
-	  start program = "/etc/init.d/stunnel4 start" with timeout 20 seconds
-	  stop program = "/etc/init.d/stunnel4 stop"
+	  start program = "/usr/sbin/service stunnel4 start" with timeout 20 seconds
+	  stop program = "/usr/sbin/service stunnel4 stop"
 	  if failed host 127.0.0.1 port {{ stunnel_remote_port }} with timeout 20 seconds then restart
     if 3 restarts within 5 cycles then unmonitor
 {% endif %}
@@ -60,16 +60,16 @@ check process stunnel4 with pidfile /var/run/stunnel4.pid
 
 # OpenSSH
 check process sshd with pidfile /var/run/sshd.pid
-   start program  "/etc/init.d/ssh start"
-   stop program  "/etc/init.d/ssh stop"
+   start program  "/usr/sbin/service ssh start"
+   stop program  "/usr/sbin/service ssh stop"
    if failed port {{ ssh_port }} protocol ssh then restart
    # if 5 restarts within 5 cycles then timeout
 
 
 # dnsmasq
 check process dnsmasq with pidfile /var/run/dnsmasq/dnsmasq.pid
-  start program = "/etc/init.d/dnsmasq start" with timeout 60 seconds
-  stop program = "/etc/init.d/dnsmasq stop"
+  start program = "/usr/sbin/service dnsmasq start" with timeout 60 seconds
+  stop program = "/usr/sbin/service dnsmasq stop"
   if failed
     host 127.0.0.1
     port 53 use type udp
@@ -93,8 +93,8 @@ check file dnsmasq-hosts with path /etc/hosts
 
 # Tinyproxy
 check process tinyproxy with pidfile /var/run/tinyproxy/tinyproxy.pid
-   start program  "/etc/init.d/tinyproxy restart"
-   stop program  "/etc/init.d/tinyproxy stop"
+   start program  "/usr/sbin/service tinyproxy start"
+   stop program  "/usr/sbin/service tinyproxy stop"
    if failed host 127.0.0.1 port 8888 type tcp then restart
    # if 5 restarts within 5 cycles then timeout
 
@@ -102,8 +102,8 @@ check process tinyproxy with pidfile /var/run/tinyproxy/tinyproxy.pid
 
 # sslh
 check process sslh with pidfile /var/run/sslh/sslh.pid
-   start program  "/etc/init.d/sslh start"
-   stop program  "/etc/init.d/sslh stop"
+   start program  "/usr/sbin/service sslh start"
+   stop program  "/usr/sbin/service sslh stop"
    if failed host {{ ansible_default_ipv4.address }} port 443 type tcp then restart
    # if 5 restarts within 5 cycles then timeout
 


### PR DESCRIPTION
When the handler to restart Nginx was skipped due to #873, Monit would start the Nginx daemon using the legacy `/etc/init.d/nginx start` command. This broke future invocations of the `service nginx restart` and `service nginx stop` commands. The same was true for other daemons that Monit launched (or re-launched).

@alimakki first documented the symptoms of this problem in #871.  Although default installations were insulated from this bug, and #873 should prevent it from occurring again in the future, Monit can still be a good init citizen until we replace it with something better.