### PR TITLE
Always do check_python()

### DIFF
--- a/streisand
+++ b/streisand
@@ -78,7 +78,6 @@ ARE YOU 100% SURE THAT YOU WISH TO CONTINUE?
 
 Please enter the word 'streisand' to continue: "
 
-  check_python
   echo; echo; ansible-playbook -i inventories/inventory-local-provision --extra-vars=@global_vars/vars.yml playbooks/localhost.yml
 }
 
@@ -116,12 +115,12 @@ EOF
 
   # Create the inventory file
   echo "$TEMPL" > inventories/inventory-existing
-  check_python
   # Invoke the Streisand playbook on the existing server inventory
   echo; echo; ansible-playbook -i inventories/inventory-existing --extra-vars=@global_vars/vars.yml playbooks/existing-server.yml
 }
 
 # Make sure the system is ready for the Streisand playbooks
+check_python
 check_ansible
 check_ssh_key
 


### PR DESCRIPTION
On Arch Linux `/usr/bin/python` is Python 3. When executing the playbook
on an Arch Linux laptop, there are actually some modules executed
locally, e.g. `ec2_*` ones. Without proper `ansible_python_interpreter` set
these tasks would fail.