### PR TITLE
shadowsocks: Make installation idempotent

### DIFF
--- a/playbooks/roles/shadowsocks/tasks/main.yml
+++ b/playbooks/roles/shadowsocks/tasks/main.yml
@@ -48,7 +48,7 @@
   command: make install
   args:
     chdir: "{{ shadowsocks_compilation_directory }}"
-    creates: "/usr/local/bin/ss-server"
+    creates: "/usr/bin/ss-server"
 
 - name: Create the shadowsocks-libev config directory
   file:


### PR DESCRIPTION
When configuring with `--prefix=/usr`, the binaries are installed under
the directory `/usr/bin` instead of `/usr/local/bin`.