### PR TITLE
ssh-forward: Allow port forwarding only

### DIFF
--- a/README-chs.md
+++ b/README-chs.md
@@ -45,7 +45,6 @@ Streisand介绍
 * [Monit](https://mmonit.com/monit/)
   * 能够监视、处理运行状态，针对那些奔溃的进程或者没有响应的进程进行自动重启和维护。
 * [OpenSSH](http://www.openssh.com/)
-  * 针对 [sshuttle](https://github.com/sshuttle/sshuttle) 的一个无特权转发用户和产生的 SSH 密钥对，同样也兼容 SOCKS；
   * 支持 Windows 和 Android 的 SSH 隧道， 并且需要使用 PuTTY 将默认的密钥对导出成 .ppk 的格式；
   * [Tinyproxy](https://banu.com/tinyproxy/) 默认安装并绑定到主机，它作为一个 http(s) 代理提供给那些原生不支持 SOCKS 代理的软件通过 SSH 隧道访问网络，比如说 Android 上的鸟嘀咕。
 * [OpenConnect](http://www.infradead.org/ocserv/index.html) / [Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)

--- a/README-fr.md
+++ b/README-fr.md
@@ -46,7 +46,6 @@ Services fournis
 * [Monit](https://mmonit.com/monit/)
   * Surveille la santé du processus et redémarre automatiquement les services dans le cas improbable où ils se plante ou ne répondent pas.
 * [OpenSSH](http://www.openssh.com/)
-  * Un utilisateur de transfert non privilégié et une paire paire de clés asymétriques SSH sont générés pour les fonctionnalités [sshuttle](https://github.com/sshuttle/sshuttle) et SOCKS.
   * Les tunnels Windows et Androïde SSH sont également pris en charge et une copie des clés sont exportée dans le format .ppk que PuTTY requiert.
   * [Tinyproxy](https://banu.com/tinyproxy/) est installé et lié à localhost. Il peut être accédé sur un tunnel SSH par des programmes qui ne prennent pas en charge nativement SOCKS et qui nécessitent un proxy HTTP, comme Twitter pour Androïde.
 * [OpenConnect](http://www.infradead.org/ocserv/index.html)/[Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Services Provided
 * [Monit](https://mmonit.com/monit/)
   * Monitors process health and automatically restarts services in the unlikely event that they crash or become unresponsive.
 * [OpenSSH](http://www.openssh.com/)
-  * An unprivileged forwarding user and SSH keypair are generated for [sshuttle](https://github.com/sshuttle/sshuttle) and SOCKS capabilities.
   * Windows and Android SSH tunnels are also supported, and a copy of the keypair is exported in the .ppk format that PuTTY requires.
   * [Tinyproxy](https://banu.com/tinyproxy/) is installed and bound to localhost. It can be accessed over an SSH tunnel by programs that do not natively support SOCKS and that require an HTTP proxy, such as Twitter for Android.
 * [OpenConnect](http://www.infradead.org/ocserv/index.html) / [Cisco AnyConnect](http://www.cisco.com/c/en/us/products/security/anyconnect-secure-mobility-client/index.html)

--- a/documentation/SOURCES.md
+++ b/documentation/SOURCES.md
@@ -40,7 +40,6 @@
 - Windows
   - [OpenVPN (from build.openvpn.net)](https://github.com/jlund/streisand/blob/master/playbooks/roles/openvpn/vars/mirror.yml)
   - [Shadowsocks (from github.com/shadowsocks)](https://github.com/jlund/streisand/blob/master/playbooks/roles/shadowsocks/vars/mirror.yml)
-  - [Shuttle (from github.com/sshuttle)](https://github.com/jlund/streisand/blob/master/playbooks/roles/streisand-mirror/vars/ssh.yml)
   - [Stunnel (from stunnel.org)](https://github.com/jlund/streisand/blob/master/playbooks/roles/stunnel/vars/mirror.yml)
   - [Putty (from the.earth.li)](https://github.com/jlund/streisand/blob/master/playbooks/roles/streisand-mirror/vars/ssh.yml)
   - [Tor Browser (from dist.torproject.org)](https://github.com/jlund/streisand/blob/master/playbooks/roles/tor-bridge/vars/mirror-common.yml)

--- a/playbooks/roles/ssh-forward/tasks/main.yml
+++ b/playbooks/roles/ssh-forward/tasks/main.yml
@@ -16,7 +16,7 @@
 - name: Authorize the key for access
   authorized_key:
     user: forward
-    key: "{{ ssh_forward_key.stdout }}"
+    key: 'command="{{ ssh_force_command }}" {{ ssh_forward_key.stdout }}'
 
 # Generate the gateway documentation for the SSH forward user
 - include: docs.yml

--- a/playbooks/roles/ssh-forward/tasks/main.yml
+++ b/playbooks/roles/ssh-forward/tasks/main.yml
@@ -21,5 +21,5 @@
 # Generate the gateway documentation for the SSH forward user
 - include: docs.yml
 
-# Mirror Putty & sshuttle for SSH forwarding from Windows
+# Mirror Putty for SSH forwarding from Windows
 - include: mirror.yml

--- a/playbooks/roles/ssh-forward/tasks/mirror.yml
+++ b/playbooks/roles/ssh-forward/tasks/mirror.yml
@@ -11,15 +11,6 @@
     state: directory
 
 - block:
-    - name: Mirror sshuttle
-      get_url:
-        url: "{{ sshuttle_url }}"
-        dest: "{{ ssh_mirror_location }}/{{ sshuttle_filename }}"
-        checksum: "{{ sshuttle_checksum }}"
-        owner: www-data
-        group: www-data
-        mode: 0644
-
     - include_role:
         name: download-and-verify
       vars:

--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -8,6 +8,7 @@ Tunnel SSH
 {% if streisand_tinyproxy_enabled %}
   * [Androïde](#android)
 {% endif %}
+  * [Notes](#notes)
 
 <a name="windows"></a>
 ### Windows ###
@@ -137,3 +138,6 @@ Certaines applications vous permettent de rendre ces paramètres persistants pou
 6. Définissez la valeur de *network.proxy.socks\_remote\_dns* à `true`.
 7. Définissez la valeur de *network.proxy.type* à `1`.
 {% endif %}
+
+<a name="notes"></a>
+1. Si vous voyez le message "This account is for port forwarding only", assurez-vous de configurer votre client SSH pour ne pas exécuter les commandes shell sur le serveur distant (`-N`).

--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -5,7 +5,6 @@ Tunnel SSH
 * Plateformes
   * [Windows](#windows)
   * [Linux et OS X](#linux-and-osx)
-  * [Linux et OS X (alternatif)](#linux-and-osx-alternate)
 {% if streisand_tinyproxy_enabled %}
   * [Androïde](#android)
 {% endif %}
@@ -56,47 +55,7 @@ Vous êtes maintenant connecté à un proxy SOCKS qui est prêt à transférer v
 1. C'est tout! Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{ streisand_ipv4_address }}*.
 
 <a name="linux-and-osx"></a>
-### Linux et OS X (sshuttle) ###
-Sshuttle est une simple solution de tunneling VPN qui fonctionne sur le transport SSH. C'est rapide, facile à installer et offre de bonnes performances.
-
-[Instructions SSH alternatifs](#linux-and-osx-alternate) sont également disponibles si vous souhaitez éviter d'installer un logiciel supplémentaire.
-
-1. Téléchargez la clé privée `streisand_rsa` qui sert à authentifier la connexion SSH:
-   * [streisand\_rsa](/ssh/streisand_rsa)
-1. Copiez le fichier `streisand_rsa` dans une répertoire de votre choix.
-1. Définissez les autorisations correctes sur le fichier clé RSA:
-   * `chmod 600 streisand_rsa`
-1. Ajoutez une nouvelle entrée à votre fichier `.ssh / config`. Il devrait ressembler à ceci.Le port `443` est disponible en option de recharge si vous êtes sur un réseau qui restreint l'accès au port SSH par défaut. Assurez-vous d'ajuster l'emplacement du IdentityFile:
-
-         Host {{ streisand_server_name }}
-           User         forward
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-           IdentityFile ~/.ssh/streisand_rsa
-
-1. Téléchargez [sshuttle](https://github.com/sshuttle/sshuttle) en exécutant la commande suivante dans une répertoire de votre choix:
-
-  `git clone https://github.com/sshuttle/sshuttle.git`
-
-  * Si l'accès à GitHub a été bloqué, vous pouvez télécharger une copie en miroir [içi](/mirror/ssh/index-fr.html)!
-  * sshuttle est également disponible via [Homebrew](http://brew.sh/) pour les utilisateurs de OS X: `brew install sshuttle`
-
-1. Entrer dans la répertoire:
-
-   `cd sshuttle`
-1. Exécutez sshuttle et connectez-vous au serveur:
-
-   `./run --dns -r forward@{{ streisand_server_name }} 0/0 -vv`
-1. Vérifiez que les empreintes numériques correspondent à l'un des éléments ci-dessous:
-
-   `{{ ssh_server_fingerprints.results[0].stdout }}`
-
-   `{{ ssh_server_fingerprints.results[1].stdout }}`
-1. Tout votre trafic, y compris DNS, est maintenant transmis de manière transparente via une connexion SSH cryptée. Vous pouvez vérifier que votre trafic est correctement routé par [recherche de votre adresse IP sur Google](https://encrypted.google.com/search?hl=fr&q=ip%20address). Il devrait dire *Votre adresse IP publique est {{ streisand_ipv4_address }}*.
-
-<a name="linux-and-osx-alternate"></a>
-### Linux et OS X (alternatif) ###
-Sshuttle offre des performances beaucoup plus rapides et est plus facile à configurer, mais les instructions suivantes vous feront aussi vous connecter si vous êtes dans une situation où vous ne pouvez pas installer sshuttle.
+### Linux et OS X ###
 1. Téléchargez la clé privée `streisand_rsa` qui sert à authentifier la connexion SSH:
    * [streisand\_rsa](/ssh/streisand_rsa)
 1. Copiez le fichier `streisand_rsa` dans une répertoire de votre choix.

--- a/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions-fr.md.j2
@@ -19,6 +19,8 @@ Tunnel SSH
    * Le port `443` est disponible en option de recharge si vous êtes sur un réseau qui restreint l'accès au port SSH par défaut.
 1. Allez à Connection --> Data.
 1. Saisissez `forward` dans le champ *Auto-login username*.
+1. Allez à Connection --> SSH.
+1. Cochez `Don't start a shell or command at all`.
 1. Allez à Connection --> SSH --> Tunnels.
 1. Saisissez `{{ ssh_default_socks_port }}` dans le champ *Source port*.
 1. Assurez-vous que les boutons radio `Auto` et `Dynamic` sont sélectionnés.

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -109,7 +109,7 @@ Sshuttle offers significantly faster performance and is easier to set up, but th
 
 1. SSH into the server and forward a dynamic SOCKS port:
 
-   `ssh -D {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
+   `ssh -ND {{ ssh_default_socks_port }} forward@{{ streisand_server_name }}`
 1. Verify that the fingerprint matches one of these:
 
    `{{ ssh_server_fingerprints.results[0].stdout }}`

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -8,6 +8,7 @@ SSH Tunnel
 {% if streisand_tinyproxy_enabled %}
   * [Android](#android)
 {% endif %}
+  * [Notes](#notes)
 
 <a name="windows"></a>
 ### Windows ###
@@ -136,3 +137,6 @@ Some applications allow you to make these settings persistent for all networks. 
 6. Set the value of *network.proxy.socks\_remote\_dns* to `true`.
 7. Set the value of *network.proxy.type* to `1`.
 {% endif %}
+
+<a name="notes"></a>
+1. If you see the message "This account is for port forwarding only", make sure you configure your SSH client to not execute shell commands on remote server (`-N`).

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -5,7 +5,6 @@ SSH Tunnel
 * Platforms
   * [Windows](#windows)
   * [Linux and OS X](#linux-and-osx)
-  * [Linux and OS X (alternate)](#linux-and-osx-alternate)
 {% if streisand_tinyproxy_enabled %}
   * [Android](#android)
 {% endif %}
@@ -56,48 +55,7 @@ You are now connected and have a SOCKS proxy up and running that is ready to for
 1. You should be good to go! You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
 
 <a name="linux-and-osx"></a>
-### Linux and OS X (sshuttle) ###
-Sshuttle is a simple VPN tunnelling solution that operates over the SSH transport. It's fast, easy to set up, and offers great performance.
-
-[Alternate SSH instructions](#linux-and-osx-alternate) are also available if you would like to avoid installing additional software.
-
-1. Download the `streisand_rsa` private key that is used to authenticate the SSH connection:
-   * [streisand\_rsa](/ssh/streisand_rsa)
-1. Copy the `streisand_rsa` file to the directory of your choice.
-1. Set the correct permissions on the RSA key file:
-   * `chmod 600 streisand_rsa`
-1. Add a new entry to your `.ssh/config` file. It should look like this. Port `443` is available as a fallback option if you are on a network that restricts access to the default SSH port. Be sure to adjust the location of the IdentityFile:
-
-         Host {{ streisand_server_name }}
-           User         forward
-           Port         {{ ssh_port }}
-           HostName     {{ streisand_ipv4_address }}
-           IdentityFile ~/.ssh/streisand_rsa
-
-1. Download [sshuttle](https://github.com/sshuttle/sshuttle) by running the following command in the directory of your choice:
-
-  `git clone https://github.com/sshuttle/sshuttle.git`
-
-  * If access to GitHub has been blocked, you can download a mirrored copy [here](/mirror/ssh/)!
-  * sshuttle is also available via [Homebrew](http://brew.sh/) for OS X users: `brew install sshuttle`
-
-1. Enter the directory:
-
-   `cd sshuttle`
-1. Run sshuttle and connect to the server:
-
-   `./run --dns -r forward@{{ streisand_server_name }} 0/0 -vv`
-1. Verify that the fingerprint matches one of these:
-
-   `{{ ssh_server_fingerprints.results[0].stdout }}`
-
-   `{{ ssh_server_fingerprints.results[1].stdout }}`
-1. All of your traffic, including DNS, is now being transparently forwarded through an encrypted SSH connection. You can verify that your traffic is being routed properly by [looking up your IP address on Google](https://encrypted.google.com/search?hl=en&q=ip%20address). It should say *Your public IP address is {{ streisand_ipv4_address }}*.
-
-<a name="linux-and-osx-alternate"></a>
-### Linux and OS X (alternate) ###
-Sshuttle offers significantly faster performance and is easier to set up, but the following instructions will also get you connected if you are in a situation where you cannot install sshuttle.
-
+### Linux and OS X ###
 1. Download the `streisand_rsa` private key that is used to authenticate the SSH connection:
    * [streisand\_rsa](/ssh/streisand_rsa)
 1. Copy the `streisand_rsa` file to the directory of your choice.

--- a/playbooks/roles/ssh-forward/templates/instructions.md.j2
+++ b/playbooks/roles/ssh-forward/templates/instructions.md.j2
@@ -19,6 +19,8 @@ SSH Tunnel
    * Port `443` is available as a fallback option if you are on a network that restricts access to the default SSH port.
 1. Go to Connection --> Data.
 1. Enter `forward` in the *Auto-login username* field.
+1. Go to Connection --> SSH.
+1. Check `Don't start a shell or command at all`.
 1. Go to Connection --> SSH --> Tunnels.
 1. Enter `{{ ssh_default_socks_port }}` in the *Source port* field.
 1. Make sure the `Auto` and `Dynamic` radio buttons are selected.

--- a/playbooks/roles/ssh-forward/templates/mirror-fr.md.j2
+++ b/playbooks/roles/ssh-forward/templates/mirror-fr.md.j2
@@ -1,11 +1,6 @@
 <a name="ssh"></a>
 ### SSH ###
 
-**Linux et OS X**
-
-* [{{ sshuttle_filename }}]({{ sshuttle_href }})
-  * Somme de contrôle: *{{ sshuttle_checksum }}*
-
 **Windows**
 
 * [{{ putty_filename }}]({{ putty_href }}) ([sig]({{ putty_sig_href }}))

--- a/playbooks/roles/ssh-forward/templates/mirror.md.j2
+++ b/playbooks/roles/ssh-forward/templates/mirror.md.j2
@@ -1,11 +1,6 @@
 <a name="ssh"></a>
 ### SSH ###
 
-**Linux and OS X**
-
-* [{{ sshuttle_filename }}]({{ sshuttle_href }})
-  * Checksum: *{{ sshuttle_checksum }}*
-
 **Windows**
 
 * [{{ putty_filename }}]({{ putty_href }}) ([sig]({{ putty_sig_href }}))

--- a/playbooks/roles/ssh-forward/vars/main.yml
+++ b/playbooks/roles/ssh-forward/vars/main.yml
@@ -1,5 +1,6 @@
 ---
 forward_location: "/home/forward"
+ssh_force_command: "echo 'This account is for port forwarding only.'"
 
 ssh_gateway_location: "{{ streisand_gateway_location }}/ssh"
 

--- a/playbooks/roles/ssh-forward/vars/mirror.yml
+++ b/playbooks/roles/ssh-forward/vars/mirror.yml
@@ -20,9 +20,3 @@ putty_sig_url: "{{ putty_base_download_url }}/{{ putty_sig_filename }}"
 putty_download_urls:
   - "{{ putty_url }}"
   - "{{ putty_sig_url }}"
-
-sshuttle_version: "0.78.0"
-sshuttle_filename: "sshuttle-{{ sshuttle_version }}.tar.gz"
-sshuttle_href: "{{ ssh_mirror_href_base }}/{{ sshuttle_filename }}"
-sshuttle_url: "https://codeload.github.com/sshuttle/sshuttle/tar.gz/v{{ sshuttle_version }}"
-sshuttle_checksum: "sha256:0742e3e670c8df629ae702a32cfad96c7c4e8f7ab8f66c26d94c55d42b01e4b4"


### PR DESCRIPTION
By default one can log into the Streisand server with the SSH private
key, which is intended for port forwarding. This poses a security issue
if a careless sysadmin sets open permissions on critical files.
Prepending a force command to authorized_key is a simple way to
prevent SSH login with that key.