### PR TITLE
Eliminate the EC2 90-second pause for ssh

### DIFF
--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -100,9 +100,3 @@
 - name: Set the streisand_server_name variable
   set_fact:
     streisand_server_name: "{{ aws_instance_name | regex_replace('\\s', '_') }}"
-
-# This does not seem to be necessary if /dev/random has been filled by haveged.
-#
-#- name: New EC2 servers are occasionally slow to process incoming SSH connections e#ven after the OpenSSH daemon has started up. Pause for 90 seconds.
-#  pause:
-#    seconds: 90

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -47,11 +47,6 @@
     instance_tags:
       Name: "{{ aws_instance_name }}"
     wait: yes
-    # This is gross, but it seems like sshd is starved for entropy on boot. We can't
-    # ssh in to fix this...
-    user_data: |
-      #!/bin/sh
-      sudo apt-get install haveged -y
   register: streisand_server
 
 - name: Create CloudWatch alarm to auto-recover instance

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -47,6 +47,11 @@
     instance_tags:
       Name: "{{ aws_instance_name }}"
     wait: yes
+    # This is gross, but it seems like sshd is starved for entropy on boot. We can't
+    # ssh in to fix this...
+    user_data: |
+      #!/bin/sh
+      sudo apt-get install haveged -y
   register: streisand_server
 
 - name: Create CloudWatch alarm to auto-recover instance
@@ -101,6 +106,8 @@
   set_fact:
     streisand_server_name: "{{ aws_instance_name | regex_replace('\\s', '_') }}"
 
-- name: New EC2 servers are occasionally slow to process incoming SSH connections even after the OpenSSH daemon has started up. Pause for 90 seconds.
-  pause:
-    seconds: 90
+# This does not seem to be necessary if /dev/random has been filled by haveged.
+#
+#- name: New EC2 servers are occasionally slow to process incoming SSH connections e#ven after the OpenSSH daemon has started up. Pause for 90 seconds.
+#  pause:
+#    seconds: 90


### PR DESCRIPTION
There's a 90-second pause in EC2 provisioning where we wait for SSH to
start working. The bug this worked around was not reproducible recently. Delete the pause.

----

Original message:

My guess was that /dev/random is starved for entropy. Use haveged at cloud-init to start gathering some entropy.

Do we trust/like haveged?

I’m leaving the 90-second pause commented out (instead of deleted), in case somebody suddenly runs into this bug again. I’m open to opinion on that.