### PR TITLE
docs: Fix undefined variable

### DIFF
--- a/playbooks/roles/streisand-gateway/templates/firewall-fr.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/firewall-fr.md.j2
@@ -42,8 +42,6 @@ Si vous installez Streisand sur un serveur existant ou un fournisseur alternatif
   * TCP - {{ shadowsocks_server_port }}
   * UDP - {{ shadowsocks_server_port }}
 {% endif %}
-* stunnel
-  * TCP - {{ stunnel_remote_port }}
 {% if streisand_tor_enabled %}
 * Tor
   * TCP - {{ tor_orport }} - Pont

--- a/playbooks/roles/streisand-gateway/templates/firewall.md.j2
+++ b/playbooks/roles/streisand-gateway/templates/firewall.md.j2
@@ -42,8 +42,6 @@ If you are installing Streisand on an existing server or alternate provider then
   * TCP - {{ shadowsocks_server_port }}
   * UDP - {{ shadowsocks_server_port }}
 {% endif %}
-* stunnel
-  * TCP - {{ stunnel_remote_port }}
 {% if streisand_tor_enabled %}
 * Tor
   * TCP - {{ tor_orport }} - Bridge


### PR DESCRIPTION
Variable `stunnel_remote_port` is only available when we have run the stunnel role. There are two references of `stunnel_remote_port` in the docs, but only one of them is surrounded by `{% if
streisand_stunnel_enabled %}{% endif %}`. This causes "AnsibleUndefinedVariable" error when we disabled stunnel role and run gateway role.

 This commit fixes the bug by surrounding the other reference with `{% if %}{% endif %}`, as well.