### PR TITLE
Always run ssh role

### DIFF
--- a/playbooks/roles/ssh-forward/meta/main.yml
+++ b/playbooks/roles/ssh-forward/meta/main.yml
@@ -1,3 +1,0 @@
----
-dependencies:
-  - { role: ssh}

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -11,6 +11,7 @@
   roles:
     - validation
     - common
+    - ssh
     # OpenConnect must be set up before L2TP/IPsec in order to avoid
     # compilation issues.
     - role: openconnect


### PR DESCRIPTION
Variable `ssh_port` is used by so many other roles, it's only set in ssh
role. But ssh role is only depended by ssh-forward role. Setting
`streisand_ssh_forward_enabled` to false destroies every reference to
`ssh_port`.