### PR TITLE
Do not show "changed" when running read-only tasks

### DIFF
--- a/playbooks/cloud-status.yml
+++ b/playbooks/cloud-status.yml
@@ -11,5 +11,6 @@
     - name: Wait for cloud-init to complete
       raw: bash -c "for i in {1..30}; do if [ -f /var/lib/cloud/instance/boot-finished ]; then exit 0; fi; sleep 1; done; exit 1;"
       register: result
+      changed_when: False
       failed_when: result.rc != 0
 ...

--- a/playbooks/google.yml
+++ b/playbooks/google.yml
@@ -103,6 +103,7 @@
     - name: Register JSON file contents
       command: cat {{ gce_json_file_location }}
       register: gce_json_file_contents
+      changed_when: False
 
     - name: Set JSON file contents fact
       set_fact:

--- a/playbooks/provider-detect.yml
+++ b/playbooks/provider-detect.yml
@@ -22,6 +22,7 @@
       #   https://serverfault.com/a/775063
       command: dmidecode -s bios-version
       register: streisand_localhost_bios_name
+      changed_when: False
 
     - name: "Set BIOS name fact"
       set_fact:
@@ -45,6 +46,7 @@
           # [0]: https://cloud.google.com/compute/docs/storing-retrieving-metadata#querying
           command: curl -H Metadata-Flavor:Google http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip
           register: streisand_gce_external_ip
+          changed_when: False
         - name: "Set the Streiand IPv4 address to the GCE external IP: {{ streisand_gce_external_ip.stdout }}"
           set_fact:
             streisand_ipv4_address: "{{ streisand_gce_external_ip.stdout }}"
@@ -63,6 +65,7 @@
         - name: "Find the external EC2 IP from Metadata"
           command: curl http://169.254.169.254/latest/meta-data/public-ipv4
           register: streisand_ec2_external_ip
+          changed_when: False
         - name: "Set the Streiand IPv4 address to the EC2 external IP: {{ streisand_ec2_external_ip.stdout }}"
           set_fact:
             streisand_ipv4_address: "{{ streisand_ec2_external_ip.stdout }}"

--- a/playbooks/roles/download-and-verify/tasks/main.yml
+++ b/playbooks/roles/download-and-verify/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: "{{ project_signer }} signs the {{ project_name }} downloads. Import the correct GPG key."
   command: gpg --keyserver {{ gpg_key_server_address }} --recv-keys {{ project_signing_key }}
   register: gpg_recv_keys_result
+  changed_when: False
   until: gpg_recv_keys_result | success
   retries: 10
   delay: 5
@@ -9,6 +10,7 @@
 - name: Register the GPG Key fingerprint output
   command: gpg --fingerprint {{ project_signing_key }}
   register: retrieved_fingerprint
+  changed_when: False
 
 - name: Make sure the retrieved fingerprint perfectly matches the expected fingerprint
   assert: { that: "project_expected_fingerprint in retrieved_fingerprint.stdout" }
@@ -33,6 +35,7 @@
   args:
     chdir: "{{ project_download_location }}"
   register: gpg_verification_results
+  changed_when: False
 
 - name: Make sure the {{ project_name }} files all passed GPG signature verfication
   assert: { that: "'BAD signature' not in gpg_verification_results.stderr" }

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
+  changed_when: False
 
 - name: Add the SSH key to Amazon under the name of 'streisand-ssh'
   ec2_key:

--- a/playbooks/roles/genesis-azure/tasks/main.yml
+++ b/playbooks/roles/genesis-azure/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
+  changed_when: False
 
 - name: Create the Azure instance
   local_action:

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -6,6 +6,7 @@
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
+  changed_when: False
 
 - block:
     - name: Add the SSH key to DigitalOcean if it doesn't already exist

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
+  changed_when: False
 
 - name: Create the GCE instance
   gce:

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -2,6 +2,7 @@
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key
+  changed_when: False
 
 - name: Create the server
   linode:

--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -62,10 +62,12 @@
 - name: Register the IPsec pre-shared key
   command: cat {{ ipsec_preshared_key_file }}
   register: ipsec_preshared_key
+  changed_when: False
 
 - name: Register the IPsec pre-shared key as base64
   shell: cat {{ ipsec_preshared_key_file }} | tr -d '\n' | base64
   register: ipsec_preshared_key_base64
+  changed_when: False
 
 - name: Generate IPsec secrets file
   template:
@@ -115,6 +117,7 @@
 - name: Register the CHAP password
   command: cat {{ chap_password_file }}
   register: chap_password
+  changed_when: False
 
 - name: Generate CHAP secrets file
   template:

--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -92,6 +92,7 @@
 - name: "Register the PKCS #12 password"
   command: cat {{ ocserv_pkcs12_password_file }}
   register: ocserv_pkcs12_password
+  changed_when: False
 
 - name: "Convert the key and certificate into PKCS #12 format"
   expect:
@@ -117,6 +118,7 @@
 - name: Register the ocserv password
   command: cat {{ ocserv_password_file }}
   register: ocserv_password
+  changed_when: False
 
 - name: Create an ocpasswd credentials file
   expect:

--- a/playbooks/roles/openvpn/tasks/main.yml
+++ b/playbooks/roles/openvpn/tasks/main.yml
@@ -59,6 +59,7 @@
 - name: Register the OpenVPN server common name
   command: cat {{ openvpn_server_common_name_file }}
   register: openvpn_server_common_name
+  changed_when: False
 
 - name: Generate the OpenSSL configuration that will be used for the Server certificate's req and ca commands
   # Properly sets the attributes that are described here:
@@ -116,6 +117,7 @@
   args:
     chdir: "{{ openvpn_path }}"
   register: openvpn_ca_contents
+  changed_when: False
 
 - name: Register client certificate contents
   command: cat client.crt
@@ -123,6 +125,7 @@
     chdir: "{{ openvpn_path }}/{{ item }}"
   with_items: "{{ openvpn_clients }}"
   register: openvpn_client_certificates
+  changed_when: False
 
 - name: Register client key contents
   command: cat client.key
@@ -130,12 +133,14 @@
     chdir: "{{ openvpn_path }}/{{ item }}"
   with_items: "{{ openvpn_clients }}"
   register: openvpn_client_keys
+  changed_when: False
 
 - name: Register HMAC firewall contents
   command: cat ta.key
   args:
     chdir: "{{ openvpn_path }}"
   register: openvpn_hmac_firewall_contents
+  changed_when: False
 
 - name: Create the client configuration profiles that will be used when connecting directly
   template:

--- a/playbooks/roles/shadowsocks/tasks/main.yml
+++ b/playbooks/roles/shadowsocks/tasks/main.yml
@@ -91,6 +91,7 @@
 - name: Register Shadowsocks password
   command: cat {{ shadowsocks_password_file }}
   register: shadowsocks_password
+  changed_when: False
 
 # Add simple-obfs task file
 - include: simple-obfs.yml

--- a/playbooks/roles/ssh-forward/tasks/main.yml
+++ b/playbooks/roles/ssh-forward/tasks/main.yml
@@ -12,6 +12,7 @@
 - name: Register the forwarding user's public SSH key
   command: cat {{ forward_location }}/.ssh/id_rsa.pub
   register: ssh_forward_key
+  changed_when: False
 
 - name: Authorize the key for access
   authorized_key:

--- a/playbooks/roles/streisand-gateway/tasks/main.yml
+++ b/playbooks/roles/streisand-gateway/tasks/main.yml
@@ -50,6 +50,7 @@
 - name: Register the Gateway password
   command: cat {{ streisand_gateway_password_file }}
   register: streisand_gateway_password
+  changed_when: False
 
 - name: Install the required package for the htpasswd command
   apt:

--- a/playbooks/roles/stunnel/tasks/mirror.yml
+++ b/playbooks/roles/stunnel/tasks/mirror.yml
@@ -30,6 +30,7 @@
   args:
     chdir: "{{ stunnel_mirror_location }}"
   register: stunnel_latest_check
+  changed_when: False
 
 - name: Set the target stunnel version
   set_fact:

--- a/playbooks/roles/tor-bridge/tasks/main.yml
+++ b/playbooks/roles/tor-bridge/tasks/main.yml
@@ -34,6 +34,7 @@
 - name: Register the bridge's random Nickname
   command: cat {{ tor_bridge_nickname_file }}
   register: tor_bridge_nickname
+  changed_when: False
 
 - name: Generate the bridge config file
   template:
@@ -92,6 +93,7 @@
 - name: Register the Tor Hidden Service hostname
   command: cat {{ tor_hidden_service_directory }}/hostname
   register: tor_hidden_service_hostname_output
+  changed_when: False
 
 - name: Register the Tor Hidden Service URL fact
   set_fact:
@@ -119,6 +121,7 @@
 - name: Discover the obfs4 certificate details
   shell: cat "{{ tor_obfs_state_directory }}/obfs4_bridgeline.txt" | grep 'Bridge obfs4' | sed -e 's/^.*cert=\(.*\) .*$/\1/'
   register: tor_obfs4_certificate
+  changed_when: False
 
 # Generate the docs gateway page
 - include: docs.yml

--- a/playbooks/roles/wireguard/tasks/main.yml
+++ b/playbooks/roles/wireguard/tasks/main.yml
@@ -14,6 +14,7 @@
 - name: Register the key file contents
   command: cat {{ item }}
   register: wireguard_key_files
+  changed_when: False
   with_items:
     - "{{ wireguard_client_private_key_file }}"
     - "{{ wireguard_client_public_key_file }}"

--- a/tests/run.yml
+++ b/tests/run.yml
@@ -22,6 +22,7 @@
         - name: Get the default SSH key
           command: "cat /tmp/id_rsa_insecure.pub"
           register: ssh_key
+          changed_when: False
 
         - name: Ensure permissions on insecure key are correct
           file:


### PR DESCRIPTION
Some tasks are just used to register file contents. These read-only tasks should not return "changed" in Ansible. Adding `changed_when: False` ensures a task no more returns "changed", only "ok" or "failed".

Hope I did not miss some tasks...