### PR TITLE
Revert "Remove GCE `ansible_user`/`become_user` (#829)"

### DIFF
--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -28,6 +28,8 @@
   add_host:
     name: "{{ streisand_server.instance_data[0].public_ip }}"
     groups: streisand-host
+    ansible_user: ubuntu
+    ansible_become: yes
 
 - name: Set the streisand_ipv4_address variable
   set_fact:


### PR DESCRIPTION
This reverts commit e04b034f0b256a791b197d267becee6b90d16e10.

It appears the GCE image is back to requiring use of the `ubuntu` user vs `root`:
> "module_stdout": "Please login as the user \"ubuntu\" rather than the user \"root\".\n\n"