### PR TITLE
Correctly limit OpenConnect clients

### DIFF
--- a/playbooks/roles/openconnect/tasks/main.yml
+++ b/playbooks/roles/openconnect/tasks/main.yml
@@ -62,10 +62,14 @@
 - name: Generate the client template file
   template:
     src: client.tmpl.j2
-    dest: "{{ ocserv_client_template_file }}"
+    dest: "{{ ocserv_path }}/client-{{ client_name.stdout }}.tmpl"
     owner: root
     group: root
     mode: 0600
+  with_items: "{{ vpn_client_names.results }}"
+  loop_control:
+    loop_var: "client_name"
+    label: "{{ client_name.item }}"
 
 - name: Generate the client keys
   command: certtool --generate-privkey --outfile {{ ocserv_path }}/{{ client_name.stdout }}-key.pem
@@ -77,7 +81,7 @@
     label: "{{ client_name.item }}"
 
 - name: Generate the client certificates
-  command: certtool --generate-certificate --load-privkey {{ ocserv_path }}/{{ client_name.stdout }}-key.pem --load-ca-certificate {{ ocserv_ca_certificate_file }} --load-ca-privkey {{ ocserv_ca_key_file }} --template {{ ocserv_client_template_file }} --outfile {{ ocserv_path }}/{{ client_name.stdout }}-cert.pem
+  command: certtool --generate-certificate --load-privkey {{ ocserv_path }}/{{ client_name.stdout }}-key.pem --load-ca-certificate {{ ocserv_ca_certificate_file }} --load-ca-privkey {{ ocserv_ca_key_file }} --template {{ ocserv_path }}/client-{{ client_name.stdout }}.tmpl --outfile {{ ocserv_path }}/{{ client_name.stdout }}-cert.pem
   args:
     creates: "{{ ocserv_path }}/{{ client_name.stdout }}-cert.pem"
   with_items: "{{ vpn_client_names.results }}"

--- a/playbooks/roles/openconnect/templates/client.tmpl.j2
+++ b/playbooks/roles/openconnect/templates/client.tmpl.j2
@@ -1,4 +1,4 @@
-cn = {{ streisand_ipv4_address }}
+cn = {{ client_name.stdout }}
 unit = "users"
 expiration_days = {{ ocserv_days_valid }}
 signing_key

--- a/playbooks/roles/openconnect/templates/config.j2
+++ b/playbooks/roles/openconnect/templates/config.j2
@@ -37,7 +37,7 @@ max-clients = {{ vpn_clients + 1 }}
 
 # Limit the number of identical clients (i.e., users connecting
 # multiple times). Unset or set to zero for unlimited. 
-max-same-clients = {{ vpn_clients + 1 }}
+max-same-clients = 1
 
 {% for item in upstream_dns_servers %}
 dns = {{ item }}

--- a/playbooks/roles/openconnect/vars/main.yml
+++ b/playbooks/roles/openconnect/vars/main.yml
@@ -47,7 +47,6 @@ ocserv_server_key_file:         "{{ ocserv_path }}/server-key.pem"
 ocserv_server_template_file:    "{{ ocserv_path }}/server.tmpl"
 
 ocserv_client_name:          "streisand-openconnect-{{ streisand_ipv4_address }}"
-ocserv_client_template_file: "{{ ocserv_path }}/client.tmpl"
 
 ocserv_hashed_password_file: "{{ ocserv_path }}/ocpasswd"
 ocserv_password_file:        "{{ ocserv_path }}/ocserv-password"


### PR DESCRIPTION
 - openconnect client certificates uses the generated VPN client names as CN rather than an IP address, allowing ocserv to distinguish between users
 - set the max-same-clients to 1

Tested on a DO droplet with multiple simultaneous users, no issues.

Edit: typo