### PR TITLE
Collect diagnostic info locally & suggest sharing in new issues

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,9 +3,6 @@ Do you have a broad question? Are you suggesting a feature, e.g. a new VPN
 service or cloud provider? If so, please create a new issue in the Streisand
 Discussions repository instead:
 https://github.com/jlund/streisand-discussions/issues/ 
-
-If you believe you have encountered a bug, please fill out the following
-template and create an issue on this repo
 -->
 
 ### Expected behavior:
@@ -15,6 +12,17 @@ template and create an issue on this repo
 ### Steps to Reproduce:
 1. 
 
+<!--
+If you have a `streisand-diagnostics.md` file in your Streisand directory please
+paste its contents below. 
+-->
+
+[ contents of `streisand-diagnostics.md` here ]
+
+<!--
+If you *do not* have a `streisand-diagnostics.md` file to share, please answer 
+the following questions below manually
+-->
 ### Additional Details:
 #### *Log output from Ansible or other relevant services (link to Gist for longer output):*
 ##### *Target Cloud Provider:*

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ ubuntu-xenial-16.04-cloudimg-console.log
 
 # Ignore changes to the existing server inventory to allow users to modify it
 inventories/inventory-existing
+
+# Ignore the Streisand diagnostics file we generate each run
+streisand-diagnostics.md

--- a/playbooks/existing-server.yml
+++ b/playbooks/existing-server.yml
@@ -15,5 +15,9 @@
   remote_user: "root"
   become: true
 
+  tasks:
+    - set_fact:
+        streisand_genesis_role: "existing-server"
+
 - include: streisand.yml
 ...

--- a/playbooks/localhost.yml
+++ b/playbooks/localhost.yml
@@ -15,6 +15,9 @@
   become: true
 
   tasks:
+    - set_fact:
+        streisand_genesis_role: "localhost"
+
     # If there's no streisand_ipv4_address set then we try our best using
     # the interface Ansible thinks is the default.
     - name: "Set the Streisand IPv4 address to the Ansible default: interface: {{ ansible_default_ipv4.alias }} address: {{ ansible_default_ipv4.address }}"

--- a/playbooks/roles/diagnostics/tasks/main.yml
+++ b/playbooks/roles/diagnostics/tasks/main.yml
@@ -1,0 +1,16 @@
+---
+- name: "Determine the git revision of the current Streisand clone"
+  command: git rev-parse HEAD
+  register: streisand_diagnostics_git_rev
+  changed_when: False
+
+# Credit to https://stackoverflow.com/a/3879077 for this approach
+- name: "Determine if there are untracked changes in the Streisand clone"
+  shell: git diff-index --quiet HEAD -- || echo "yes";
+  register: streisand_diagnostics_git_untracked
+  changed_when: False
+
+- name: "Produce the diagnostics markdown file to share if there is an error"
+  template:
+    src: streisand-diagnostics.md.j2
+    dest: ../streisand-diagnostics.md

--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -1,0 +1,36 @@
+<!--
+
+Please share the contents of this file when you open a new Streisand issue
+https://github.com/jlund/streisand-discussions/issues/ 
+
+It will help the developers reproduce your problem and provide a fix.
+-->
+
+### Ansible Information
+
+* Ansible version: {{ hostvars['localhost']['ansible_version']['full'] }}
+* Ansible arch: {{ hostvars['localhost']['ansible_architecture'] }}
+* Ansible system: {{ hostvars['localhost']['ansible_system'] }}
+* Host OS: {{ hostvars['localhost']['ansible_distribution'] }}
+* Host OS version:  {{ hostvars['localhost']['ansible_distribution_version'] }}
+* Python interpreter: {{ hostvars['localhost']['ansible_python_interpreter'] }}
+* Python version: {{ hostvars['localhost']['ansible_python_version'] }}
+
+### Streisand Information
+
+* Streisand Git revision: {{ streisand_diagnostics_git_rev.stdout }}
+* Streisand Git clone has untracked changes: {{ streisand_diagnostics_git_untracked.stdout }}
+* Genesis role: {{ streisand_genesis_role }}
+
+### Enabled Roles
+
+* Shadowsocks enabled:  {{ streisand_shadowsocks_enabled }}
+* Wireguard enabled: {{ streisand_wireguard_enabled }}
+* OpenVPN enabled: {{ streisand_openvpn_enabled }}
+* stunnel enabled: {{ streisand_stunnel_enabled }}
+* Tor enabled: {{ streisand_tor_enabled }}
+* Openconnect enabled: {{ streisand_openconnect_enabled }}
+* TinyProxy enabled: {{ streisand_tinyproxy_enabled }}
+* SSH forward user enabled: {{ streisand_ssh_forward_enabled }}
+* L2TP enabled: {{ streisand_l2tp_enabled }}
+* Configured number of VPN clients: {{ vpn_clients }}

--- a/playbooks/roles/genesis-amazon/tasks/main.yml
+++ b/playbooks/roles/genesis-amazon/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-amazon"
+
 - name: Remove the 'streisand' SSH key from Amazon if it already exists. This is to prevent problems if two people with two different keys are sharing the same AWS account.
   ec2_key:
     name: streisand-ssh

--- a/playbooks/roles/genesis-azure/tasks/main.yml
+++ b/playbooks/roles/genesis-azure/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-azure"
+
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key

--- a/playbooks/roles/genesis-digitalocean/tasks/main.yml
+++ b/playbooks/roles/genesis-digitalocean/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-digitalocean"
+
 - name: Set the DigitalOcean Access Token fact to the value that was entered, or attempt to retrieve it from the environment if the entry is blank
   set_fact:
     do_access_token: "{{ do_access_token_entry | default( lookup('env', 'DO_API_KEY') ) }}"

--- a/playbooks/roles/genesis-google/tasks/main.yml
+++ b/playbooks/roles/genesis-google/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-google"
+
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key

--- a/playbooks/roles/genesis-linode/tasks/main.yml
+++ b/playbooks/roles/genesis-linode/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-linode"
+
 - name: Get the default SSH key
   command: cat ~/.ssh/id_rsa.pub
   register: ssh_key

--- a/playbooks/roles/genesis-rackspace/tasks/main.yml
+++ b/playbooks/roles/genesis-rackspace/tasks/main.yml
@@ -1,4 +1,7 @@
 ---
+- set_fact:
+    streisand_genesis_role: "genesis-rackspace"
+
 - name: Create the server
   rax:
     api_key: "{{ rackspace_api_key }}"

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -5,7 +5,8 @@
   hosts: localhost
   gather_facts: no
   roles:
-    - diagnostics
+    - role: diagnostics
+      when: not streisand_ci
 
 - name: Configure the Server and install required software
 # ========================================================

--- a/playbooks/streisand.yml
+++ b/playbooks/streisand.yml
@@ -1,6 +1,12 @@
 ---
 - include: python.yml
 
+- name: Collect diagnostics in case of error
+  hosts: localhost
+  gather_facts: no
+  roles:
+    - diagnostics
+
 - name: Configure the Server and install required software
 # ========================================================
   hosts: streisand-host


### PR DESCRIPTION
This commit adds a diagnostics role that is used to collect information
about the Ansible installation & the Streisand clone being run. This
information is written to `streisand-diagnostics.md` in the project
directory but **not shared anywhere**. Care was taken to not include
anything that is especially sensitive (e.g. IP addresses, BIOS info).

The information written to the `streisand-diagnostics.md` file includes:
* Ansible version
* Host OS/version
* Python version
* Streisand git revision
* Whether there are untracked changes in the git clone (e.g. you've
  mucked about!)
* The genesis role that was being used (Linode, EC2, Localhost, etc)
* Which optional roles were enabled
* How many VPN clients were being configured

This commit updates the Github issue template to indicate that users
opening new issues about Streisand should share the
`streisand-diagnostics.md` file contents. This should make
troubleshooting much easier for everyone!

To be 1000% clear: no information is collected and sent to anyone
without the user doing it themselves as part of a Github issue.