### PR TITLE
Update shadowsocks android client mirror to v4.2.5.

### DIFF
--- a/playbooks/roles/shadowsocks/vars/mirror.yml
+++ b/playbooks/roles/shadowsocks/vars/mirror.yml
@@ -5,11 +5,11 @@ shadowsocks_mirror_location: "{{ streisand_mirror_location }}/shadowsocks"
 shadowsocks_mirror_href_base: "/mirror/shadowsocks"
 
 # Android
-shadowsocks_android_version: "4.2.2"
+shadowsocks_android_version: "4.2.5"
 shadowsocks_android_filename: "shadowsocks-nightly-{{ shadowsocks_android_version }}.apk"
 shadowsocks_android_href: "{{ shadowsocks_mirror_href_base }}/{{ shadowsocks_android_filename }}"
 shadowsocks_android_url: "https://github.com/shadowsocks/shadowsocks-android/releases/download/v{{ shadowsocks_android_version }}/shadowsocks-nightly-{{ shadowsocks_android_version }}.apk"
-shadowsocks_android_checksum: "sha256:0d15d2bce65f5c7b13a3c86e5d1bd98a216ffdf70460cd273d851d7da8d3f60c"
+shadowsocks_android_checksum: "sha256:81147c9dc5bf3f1a5c5030ef0bd21c9665c83b49ddf50b11331bca6cd0aa8b2f"
 
 # Windows
 shadowsocks_gui_version: "4.0.4"


### PR DESCRIPTION
https://github.com/shadowsocks/shadowsocks-android/releases/tag/v4.2.5