### PR TITLE
Remove `ansible_architecture` from diagnostics.

### DIFF
--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -9,7 +9,6 @@ It will help the developers reproduce your problem and provide a fix.
 ### Ansible Information
 
 * Ansible version: {{ hostvars['localhost']['ansible_version']['full'] }}
-* Ansible arch: {{ hostvars['localhost']['ansible_architecture'] }}
 * Ansible system: {{ hostvars['localhost']['ansible_system'] }}
 * Host OS: {{ hostvars['localhost']['ansible_distribution'] }}
 * Host OS version:  {{ hostvars['localhost']['ansible_distribution_version'] }}


### PR DESCRIPTION
Seems that some versions of Ansible we support don't have this var
defined (https://github.com/jlund/streisand/issues/931). It would be easy enough to work around this with a default
value but I was on the fence about the value of including it to begin
with so for now out it goes!

