### PR TITLE
Use defaults when accessing hostvars for diagnostics.

### DIFF
--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -8,12 +8,12 @@ It will help the developers reproduce your problem and provide a fix.
 
 ### Ansible Information
 
-* Ansible version: {{ hostvars['localhost']['ansible_version']['full'] }}
-* Ansible system: {{ hostvars['localhost']['ansible_system'] }}
-* Host OS: {{ hostvars['localhost']['ansible_distribution'] }}
-* Host OS version:  {{ hostvars['localhost']['ansible_distribution_version'] }}
-* Python interpreter: {{ hostvars['localhost']['ansible_python_interpreter'] }}
-* Python version: {{ hostvars['localhost']['ansible_python_version'] }}
+* Ansible version: {{ hostvars.get('localhost', {}).get('ansible_version', {}).get('full','Unknown') }}
+* Ansible system: {{ hostvars.get('localhost', {}).get('ansible_system', 'Unknown') }}
+* Host OS: {{ hostvars.get('localhost', {}).get('ansible_distribution', 'Unknown') }}
+* Host OS version:  {{ hostvars.get('localhost', {}).get('ansible_distribution_version', 'Unknown') }}
+* Python interpreter: {{ hostvars.get('localhost', {}).get('ansible_python_interpreter', 'Unknown') }}
+* Python version: {{ hostvars.get('localhost', {}).get('ansible_python_version', 'Unknown') }}
 
 ### Streisand Information
 


### PR DESCRIPTION
This commit updates the `hostvar`'s referenced in the
`streisand-diagnostics md.j2` template to assume nothing about which
vars are/aren't present on the system. For mysterious reasons it seems
like sometimes the same version of Ansible will have different hostvars
populated. Since we intend for this diagnostics information to be useful
in cases when things are already going wrong we should take the most
conservative approach possible in collecting the information.

This commit updates the template to use the `.get()` style of accessing
Python dictionary keys, providing a default value in the event the key
isn't present. This should allow for the template to render even when
none of the referenced Ansible hostvars are available.

Updates #931