### PR TITLE
Conditionally access hostvar keys for diagnostics.

### DIFF
--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -8,12 +8,40 @@ It will help the developers reproduce your problem and provide a fix.
 
 ### Ansible Information
 
+{% if 'localhost' in hostvars %}
+{% if 'ansible_version' in hostvars['localhost'] %}
 * Ansible version: {{ hostvars['localhost']['ansible_version']['full'] }}
+{% else %}
+* Ansible version: Unknown
+{% endif %}
+{% if 'ansible_system' in hostvars['localhost'] %}
 * Ansible system: {{ hostvars['localhost']['ansible_system'] }}
+{% else %}
+* Ansible system: Unknown
+{% endif %}
+{% if 'ansible_distribution' in hostvars['localhost'] %}
 * Host OS: {{ hostvars['localhost']['ansible_distribution'] }}
+{% else %}
+* Host OS: Unknown
+{% endif %}
+{% if 'ansible_distribution_version' in hostvars['localhost'] %}
 * Host OS version:  {{ hostvars['localhost']['ansible_distribution_version'] }}
+{% else %}
+* Host OS version: Unknown
+{% endif %}
+{% if 'ansible_python_interpreter' in hostvars['localhost'] %}
 * Python interpreter: {{ hostvars['localhost']['ansible_python_interpreter'] }}
+{% else %}
+* Python interpreter: Unknown
+{% endif %}
+{% if 'ansible_python_version' in hostvars['localhost'] %}
 * Python version: {{ hostvars['localhost']['ansible_python_version'] }}
+{% else %}
+* Python version: Unknown
+{% endif %}
+{% else %}
+* No 'localhost' in hostvars. Ansible information unknown.
+{% endif %}
 
 ### Streisand Information
 


### PR DESCRIPTION
This commit updates the `streisand-diagnostics md.j2` template to
conditionally reference hostvars for diagnostics. If the hostvars don't
exist the diagnostic is templated as Unknown.

For mysterious reasons it seems like sometimes the same version of
Ansible will have different hostvars populated. Since we intend for this
diagnostics information to be useful in cases when things are already
going wrong we should take the most conservative approach possible in
collecting the information.

One might be tempted to use `.get('foo', 'Unknown')` or similar instead
of a mess of `if/else/endif` blocks. Unfortunately the Ansible
`hostvars` var isn't a normal dict and this will still fail if `'foo'`
isn't defined.

Updates #931