### PR TITLE
Fix Azure Python dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Complete all of these tasks on your local home machine.
         sudo pip install boto
   * Azure
 
-        sudo pip install msrest msrestazure azure==2.0.0rc5
+        sudo pip install msrest msrestazure azure==2.0.0rc5 packaging
   * DigitalOcean
 
         sudo pip install dopy==0.3.5


### PR DESCRIPTION
Without `packaging`, the following error emits:

```
TASK [azure-security-group : Create Azure resource group] **********************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: ImportError: No module named packaging.version
```

Fixes #735