### PR TITLE
Fix missing `streisand_shadowsocks_enabled` check in validation role.

### DIFF
--- a/playbooks/roles/validation/tasks/main.yml
+++ b/playbooks/roles/validation/tasks/main.yml
@@ -20,6 +20,7 @@
   when: (not streisand_l2tp_enabled)
     and (not streisand_openconnect_enabled)
     and (not streisand_openvpn_enabled)
+    and (not streisand_shadowsocks_enabled)
     and (not streisand_ssh_forward_enabled)
     and (not streisand_tor_enabled)
     and (not streisand_wireguard_enabled)


### PR DESCRIPTION
The validation role didn't include `streisand_shadowsocks_enabled` in
the boolean logic used to decide if no VPN services were enabled. As
a result configuring Streisand with only shadowsocks enabled fails. This
commit adds `streisand_shadowsocks_enabled` to the validation check and
now you can provision a Streisand node that has only shadowsocks-libev.
