### PR TITLE
Update shadowsocks-libev to 3.1.0, simple-obfs to tip of master.

### DIFF
--- a/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
+++ b/playbooks/roles/shadowsocks/tasks/simple-obfs.yml
@@ -3,7 +3,7 @@
   git:
     repo: "https://github.com/shadowsocks/simple-obfs"
     dest: "{{ simple_obfs_compilation_directory }}"
-    version: "v{{simple_obfs_version}}"
+    version: "{{simple_obfs_version}}"
     # NOTE(@cpu): this force can be removed once a release >0.0.3 of simple-obfs
     # is cut. There is a cached git copy of aclocal.m4 that causes untracked
     # changes in 0.0.3 fixed with 8c22d on simple-obfs master.

--- a/playbooks/roles/shadowsocks/vars/main.yml
+++ b/playbooks/roles/shadowsocks/vars/main.yml
@@ -14,12 +14,12 @@ shadowsocks_dependencies:
   - libmbedtls-dev
   - libpcre3-dev
   - libsodium-dev
-  - libudns-dev
+  - libc-ares-dev
   # Shadowsocks may complain about lack of entropy without rng-tools installed
   - rng-tools
   - libssl-dev
 
-shadowsocks_version: "3.0.8"
+shadowsocks_version: "3.1.0"
 shadowsocks_compilation_directory: "/usr/local/src/shadowsocks-libev-{{ shadowsocks_version }}"
 
 # Configuring the build without documentation means we save close to 900mb of deps
@@ -30,7 +30,12 @@ shadowsocks_location: "/etc/shadowsocks-libev"
 shadowsocks_password_file: "{{ shadowsocks_location }}/shadowsocks-password.txt"
 
 # simple-obfs vars
-simple_obfs_version: "0.0.3"
+# TODO(@cpu): Once a simple-obfs release > 0.0.3 has been cut we can switch back
+# to cloning a specific release instead of this commit that was the tip of
+# master at the time of writing. Presently 0.0.3 is the latest release and is
+# missing a segfault fix and retains udns support while we build
+# shadowsocks-libev with cares now
+simple_obfs_version: "2955a57624add482588b41fad68bbcd4c632fff5"
 simple_obfs_compilation_directory: "/usr/local/src/shadowsocks-simple-obfs-{{ simple_obfs_version }}"
 simple_obfs_configure_flags: "--disable-documentation"
 


### PR DESCRIPTION
This commit updates the git source of `shadowsocks-libev` that Streisand
clones to version 3.1.0. This release removes udns support so we can
drop `libundns-dev` from `shadowsocks_dependencies`. Shadowsocks-libev
now uses `libc-ares-dev` so we add that dep in its place.

Unfortunately the latest tagged release of simple-obfs is 0.0.3 and
still uses `libudns-dev`. This commit switches to cloning the tip of
master while waiting for a release.

I tested a Shadowsocks Android client against a fresh server both with
and without simple-obfs and both worked correctly using a 3.1.0 server.