### PR TITLE
Launch L2TP/IPsec services via systemd

### DIFF
--- a/playbooks/roles/l2tp-ipsec/tasks/main.yml
+++ b/playbooks/roles/l2tp-ipsec/tasks/main.yml
@@ -151,6 +151,15 @@
     mode: 0750
     state: directory
 
+- name: Enable and start L2TP/IPsec services
+  service:
+    name: "{{ item }}"
+    state: restarted
+    enabled: yes
+  with_items:
+    - ipsec
+    - xl2tpd
+
 - name: Generate the Markdown L2TP/IPsec instructions
   template:
     src: "instructions{{ item.value.file_suffix }}.md.j2"

--- a/playbooks/roles/rc-local/templates/rc.local.j2
+++ b/playbooks/roles/rc-local/templates/rc.local.j2
@@ -34,9 +34,6 @@
 {% endfor %}
 {% endif %}
 
-ipsec setup start
-/etc/init.d/xl2tpd restart
-
 echo 1 > /proc/sys/net/ipv4/ip_forward
 
 echo 0 | tee /proc/sys/net/ipv4/conf/*/*_redirects


### PR DESCRIPTION
This is first step on moving all service management and monitoring under systemd.

`libreswan` install proper `ipsec.service` which includes safety checks and automatic restart of failure. `xl2tpd` service file which comes from ubuntu repo, have explicit `Restart=no`. I don't know history of this yet, but will investigate it, but this behavior can be easily overridden with drop in config.