### PR TITLE
Always use `iptables` with `--wait` in firewall rules.

### DIFF
--- a/playbooks/roles/common/vars/main.yml
+++ b/playbooks/roles/common/vars/main.yml
@@ -50,6 +50,13 @@ streisand_footer_template: "/tmp/footer.html"
 streisand_language_selector: "/tmp/languages.html"
 streisand_i18n_header_template: "/tmp/headeri18n.html"
 
+# By default concurrent executions of `iptables` will fail immediately if unable
+# to acquire a lock. We use the `--wait` argument to instead specify a maximum
+# number of seconds to wait before failing. This allows multiple services to add
+# iptables rules at once. See Issue #950 for longer term ideas on how to make
+# this var not required.
+streisand_iptables_wait: 120
+
 # Internationalization
 streisand_languages:
   en:

--- a/playbooks/roles/l2tp-ipsec/vars/main.yml
+++ b/playbooks/roles/l2tp-ipsec/vars/main.yml
@@ -28,15 +28,15 @@ libreswan_developers_key_id: "0x85FF4B43B30FC6F9"
 libreswan_developers_expected_fingerprint: "Key fingerprint = 907E 790F 25C1 E8E5 61CD  73B5 85FF 4B43 B30F C6F9"
 
 l2tp_ipsec_firewall_rules:
-  - iptables -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-  - iptables -A INPUT -i lo -j ACCEPT
-  - iptables -A INPUT -p udp --dport 67:68 --sport 67:68 -j ACCEPT
-  - iptables -A INPUT -p udp -m multiport --dports 500,4500 -j ACCEPT
-  - iptables -A INPUT -p udp --dport 1701 -m policy --dir in --pol ipsec -j ACCEPT
-  - iptables -A INPUT -p udp --dport 1701 -j DROP
-  - iptables -A FORWARD -i eth+ -o ppp+ -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
-  - iptables -A FORWARD -i ppp+ -o eth+ -j ACCEPT
-  - iptables -t nat -A POSTROUTING -s 192.168.42.0/24 -o eth+ -j SNAT --to-source {{ ansible_default_ipv4.address }}
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -i lo -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -p udp --dport 67:68 --sport 67:68 -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -p udp -m multiport --dports 500,4500 -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -p udp --dport 1701 -m policy --dir in --pol ipsec -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A INPUT -p udp --dport 1701 -j DROP"
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -i eth+ -o ppp+ -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -i ppp+ -o eth+ -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -s 192.168.42.0/24 -o eth+ -j SNAT --to-source {{ ansible_default_ipv4.address }}"
 
 l2tp_ipsec_gateway_location: "{{ streisand_gateway_location }}/l2tp-ipsec"
 

--- a/playbooks/roles/openconnect/vars/main.yml
+++ b/playbooks/roles/openconnect/vars/main.yml
@@ -1,7 +1,7 @@
 ---
 ocserv_path: "/etc/ocserv"
 ocserv_config_file: "{{ ocserv_path }}/config"
-ocserv_firewall_rule: "iptables -t nat -A POSTROUTING -j MASQUERADE"
+ocserv_firewall_rule: "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -j MASQUERADE"
 
 ocserv_days_valid: "1825"
 ocserv_dependencies:

--- a/playbooks/roles/openvpn/vars/main.yml
+++ b/playbooks/roles/openvpn/vars/main.yml
@@ -17,10 +17,10 @@ dnsmasq_openvpn_tcp_ip: "10.8.0.1"
 dnsmasq_openvpn_udp_ip: "10.9.0.1"
 
 openvpn_firewall_rules:
-  - iptables -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT
-  - iptables -A FORWARD -s 10.8.0.0/24 -j ACCEPT
-  - iptables -A FORWARD -s 10.9.0.0/24 -j ACCEPT
-  - iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE
-  - iptables -t nat -A POSTROUTING -s 10.9.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -m state --state RELATED,ESTABLISHED -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -s 10.8.0.0/24 -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -s 10.9.0.0/24 -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -s 10.8.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE"
+  - "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -s 10.9.0.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE"
 
 openvpn_gateway_location: "{{ streisand_gateway_location }}/openvpn"

--- a/playbooks/roles/wireguard/vars/main.yml
+++ b/playbooks/roles/wireguard/vars/main.yml
@@ -8,7 +8,7 @@ wireguard_server_public_key_file:  "{{ wireguard_path }}/server.pub"
 dnsmasq_wireguard_ip: "10.192.122.1"
 
 wireguard_firewall_rules:
-  - iptables -A FORWARD -s 10.192.122.0/24 -j ACCEPT
-  - iptables -t nat -A POSTROUTING -s 10.192.122.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE
+  - "iptables --wait {{ streisand_iptables_wait }} -A FORWARD -s 10.192.122.0/24 -j ACCEPT"
+  - "iptables --wait {{ streisand_iptables_wait }} -t nat -A POSTROUTING -s 10.192.122.0/24 -o {{ ansible_default_ipv4.interface }} -j MASQUERADE"
 
 wireguard_gateway_location:      "{{ streisand_gateway_location }}/wireguard"


### PR DESCRIPTION
Per `man iptables`:
```
   -w, --wait [seconds]
      Wait  for  the xtables lock.  To prevent multiple instances of the
      program from running concurrently, an attempt will be made to
      obtain an exclusive lock at launch.  By default, the program will
      exit if the  lock  cannot  be  obtained. This  option  will  make
      the  program  wait  (indefinitely  or for optional seconds) until
      the exclusive lock can be obtained.
```

Since Streisand presently uses `iptables` in multiple services at boot
without explicit coordination it makes sense to wait a little longer when
invoking `iptables`. We will suffer the boot time slowdown that may
occur until we can perform a larger firewall cleanup (See Issue #950).

By default we now wait 120 seconds as specified in the `common`
playbook's `streisand_iptables_wait` var. It was tempting to use `-w`
and save having to define yet another var but I'm uncomfortable with
the idea of locking the system up at boot forever if something wiggly
happens with `iptables`.

Resolves https://github.com/jlund/streisand/issues/948