### PR TITLE
Set a default value for the Genesis Role diagnostic variable.

### DIFF
--- a/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
+++ b/playbooks/roles/diagnostics/templates/streisand-diagnostics.md.j2
@@ -47,7 +47,7 @@ It will help the developers reproduce your problem and provide a fix.
 
 * Streisand Git revision: {{ streisand_diagnostics_git_rev.stdout }}
 * Streisand Git clone has untracked changes: {{ streisand_diagnostics_git_untracked.stdout }}
-* Genesis role: {{ streisand_genesis_role }}
+* Genesis role: {{ streisand_genesis_role | default("None") }}
 
 ### Enabled Roles
 


### PR DESCRIPTION
This fixes an error that was otherwise occurring when running one of the advanced installation options against an existing server.

Resolves https://github.com/jlund/streisand/issues/956